### PR TITLE
fix ip_pool bug when there are >25 pools

### DIFF
--- a/gen/definitions/ip_pool.yaml
+++ b/gen/definitions/ip_pool.yaml
@@ -57,4 +57,3 @@ attributes:
     type: StringList
     description: List of DNS Server IPs
     example: 2.3.4.5
-

--- a/internal/provider/data_source_catalystcenter_ip_pool.go
+++ b/internal/provider/data_source_catalystcenter_ip_pool.go
@@ -121,7 +121,6 @@ func (d *IPPoolDataSource) Configure(_ context.Context, req datasource.Configure
 
 //template:end model
 
-//template:begin read
 func (d *IPPoolDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var config IPPool
 
@@ -134,7 +133,7 @@ func (d *IPPoolDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Read", config.Id.String()))
 	if config.Id.IsNull() && !config.Name.IsNull() {
-		res, err := d.client.Get("/api/v2/ippool")
+		res, err := d.client.Get("/api/v2/ippool?limit=500")
 		if err != nil {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve objects, got error: %s", err))
 			return
@@ -171,5 +170,3 @@ func (d *IPPoolDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	diags = resp.State.Set(ctx, &config)
 	resp.Diagnostics.Append(diags...)
 }
-
-//template:end read

--- a/internal/provider/resource_catalystcenter_ip_pool.go
+++ b/internal/provider/resource_catalystcenter_ip_pool.go
@@ -151,8 +151,8 @@ func (r *IPPoolResource) Create(ctx context.Context, req resource.CreateRequest,
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (POST), got error: %s, %s", err, res.String()))
 		return
 	}
-	params = ""
-	res, err = r.client.Get("/api/v2/ippool?limit=500" + params)
+
+	res, err = r.client.Get("/api/v2/ippool?limit=500")
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object (GET), got error: %s, %s", err, res.String()))
 		return

--- a/internal/provider/resource_catalystcenter_ip_pool.go
+++ b/internal/provider/resource_catalystcenter_ip_pool.go
@@ -130,7 +130,6 @@ func (r *IPPoolResource) Configure(_ context.Context, req resource.ConfigureRequ
 
 //template:end model
 
-//template:begin create
 func (r *IPPoolResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan IPPool
 
@@ -153,7 +152,7 @@ func (r *IPPoolResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 	params = ""
-	res, err = r.client.Get("/api/v2/ippool" + params)
+	res, err = r.client.Get("/api/v2/ippool?limit=500" + params)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object (GET), got error: %s, %s", err, res.String()))
 		return
@@ -165,8 +164,6 @@ func (r *IPPoolResource) Create(ctx context.Context, req resource.CreateRequest,
 	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 }
-
-//template:end create
 
 //template:begin read
 func (r *IPPoolResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {


### PR DESCRIPTION
Before the change, the `make testacc` mostly failed on an environment with >25 IP pools existing. Now it succeeds.

Why does the PR not use code generation: GET is sometimes used with suffix `?limit=` and sometimes with suffix `/uuid`, which seems like a unique situation. Not worth to further complicate the templates in my opinion.

What failure was fixed:

```
$ SKIP_MINIMUM_TEST=1 TF_ACC=1 go test -count 1 -v -run TestAccCcIPPool ./...
?       github.com/CiscoDevNet/terraform-provider-catalystcenter        [no test files]
?       github.com/CiscoDevNet/terraform-provider-catalystcenter/internal/provider/helpers      [no test files]
=== RUN   TestAccCcIPPoolReservation
    resource_catalystcenter_ip_pool_reservation_test.go:48: Step 1/1 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement

        Terraform will perform the following actions:

          # catalystcenter_ip_pool.test must be replaced
        -/+ resource "catalystcenter_ip_pool" "test" {
              + id               = (known after apply)
              + ip_subnet        = "172.32.0.0/16"
              + name             = "MyPool1" # forces replacement
                # (2 unchanged attributes hidden)
            }

        Plan: 1 to add, 0 to change, 1 to destroy.
    testing_new.go:91: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: Client Error

        Failed to delete object (DELETE), got error: task
        '30f68d74-a8a5-4973-aa2f-d661bd9fea4f' failed: {"message":"Global pool id
        parameter should not be empty to delete the global pool
        detail.","status":"false"}, {
          "bapiKey" : "1eaa-8b21-48ab-81de",
          "bapiName" : "Delete Global IP Pool",
          "bapiExecutionId" : "30f68d74-a8a5-4973-aa2f-d661bd9fea4f",
          "startTime" : "Mon Mar 04 07:33:36 UTC 2024",
          "startTimeEpoch" : 1709537616846,
          "endTime" : "Mon Mar 04 07:33:37 UTC 2024",
          "endTimeEpoch" : 1709537617102,
          "timeDuration" : 256,
          "status" : "FAILURE",
          "bapiError" : "{\"message\":\"Global pool id parameter should not be empty to delete the global pool detail.\",\"status\":\"false\"}",
          "runtimeInstanceId" : "DNACP_Runtime_1dc15bfb-3f38-4c36-aac7-acf657b8ac4d"
        }
--- FAIL: TestAccCcIPPoolReservation (28.27s)
=== RUN   TestAccCcIPPool
    resource_catalystcenter_ip_pool_test.go:56: Step 1/2 error: Error running apply: exit status 1

        Error: Client Error

          with catalystcenter_ip_pool.test,
          on terraform_plugin_test.tf line 11, in resource "catalystcenter_ip_pool" "test":
          11: resource "catalystcenter_ip_pool" "test" {

        Failed to configure object (POST), got error: HTTP Request failed: StatusCode
        500, {"status":false,"errorMessage":[{"ippool":["NCIP10251: A pool named
        MyPool1 already exists, which conflicts with the proposed global pool. for ip
        pool name MyPool1."]}]}
--- FAIL: TestAccCcIPPool (3.46s)
FAIL
FAIL    github.com/CiscoDevNet/terraform-provider-catalystcenter/internal/provider      31.734s
FAIL
```