### PR TITLE
Modified wireless_profile to use v2 API endpoint, fix #73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Fix `mfp_client_protection` attribute validation of `catalystcenter_wireless_enterprise_ssid` resource, [link](https://github.com/CiscoDevNet/terraform-provider-catalystcenter/issues/74)
 
+- BREAKING CHANGE: Modified `wireless_profile` resource to use /dna/intent/api/v2/wireless/profile API endpoint, this resource only works with DNAC version 2.3.7.5+
+
 ## 0.1.8
 
 - Fix import functionality for resources with multipart keys, e.g. `catalystcenter_ip_pool_reservation`

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -11,6 +11,8 @@ description: |-
 
 - Fix `mfp_client_protection` attribute validation of `catalystcenter_wireless_enterprise_ssid` resource, [link](https://github.com/CiscoDevNet/terraform-provider-catalystcenter/issues/74)
 
+- BREAKING CHANGE: Modified `wireless_profile` resource to use /dna/intent/api/v2/wireless/profile API endpoint, this resource only works with DNAC version 2.3.7.5+
+
 ## 0.1.8
 
 - Fix import functionality for resources with multipart keys, e.g. `catalystcenter_ip_pool_reservation`

--- a/docs/resources/wireless_profile.md
+++ b/docs/resources/wireless_profile.md
@@ -3,12 +3,12 @@
 page_title: "catalystcenter_wireless_profile Resource - terraform-provider-catalystcenter"
 subcategory: "Wireless"
 description: |-
-  This resource creates a wireless network profile. To associate a wireless network profile with a site, use the catalystcenter_associate_site_to_network_profile resource.
+  This resource creates a wireless network profile. To associate a wireless network profile with a site, use the catalystcenter_associate_site_to_network_profile resource. This resource only works with 2.3.7.5+ DNAC version
 ---
 
 # catalystcenter_wireless_profile (Resource)
 
-This resource creates a wireless network profile. To associate a wireless network profile with a site, use the `catalystcenter_associate_site_to_network_profile` resource.
+This resource creates a wireless network profile. To associate a wireless network profile with a site, use the `catalystcenter_associate_site_to_network_profile` resource. This resource only works with 2.3.7.5+ DNAC version
 
 ## Example Usage
 
@@ -55,3 +55,11 @@ Optional:
 - `local_to_vlan` (Number) Local To Vlan Id
 - `policy_profile_name` (String) Policy Profile Name
 - `wlan_profile_name` (String) WLAN Profile Name
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import catalystcenter_wireless_profile.example "<id>"
+```

--- a/examples/resources/catalystcenter_wireless_profile/import.sh
+++ b/examples/resources/catalystcenter_wireless_profile/import.sh
@@ -1,0 +1,1 @@
+terraform import catalystcenter_wireless_profile.example "<id>"

--- a/gen/definitions/wireless_profile.yaml
+++ b/gen/definitions/wireless_profile.yaml
@@ -1,32 +1,29 @@
 ---
 name: Wireless Profile
-rest_endpoint: /dna/intent/api/v1/wireless/profile
-delete_rest_endpoint: /dna/intent/api/v1/wireless-profile
-id_query_param: profileName
-id_from_query_path: 0.profileDetails
-no_import: true
+rest_endpoint: /dna/intent/api/v2/wireless/profile
+id_from_query_path: response
+get_from_all: true
 no_data_source: true
 put_no_id: true
 id_from_query_path_attribute: instanceUuid
 res_description:
   'This resource creates a wireless network profile. To associate a wireless network profile with a site, use 
-  the `catalystcenter_associate_site_to_network_profile` resource.'
+  the `catalystcenter_associate_site_to_network_profile` resource. This resource only works with 2.3.7.5+ DNAC version'
 doc_category: Wireless
 attributes:
-  - model_name: name
-    response_data_path: 0.profileDetails.name
-    data_path: profileDetails
+  - model_name: wirelessProfileName
+    tf_name: name
+    delete_query_param: true
     type: String
-    id: true
+    match_id: true
     description: Profile Name
     example: Wireless_Profile_1
   - model_name: ssidDetails
-    response_data_path: 0.profileDetails.ssidDetails
-    data_path: profileDetails
     type: List
     description: SSID Details
     attributes:
-      - model_name: name
+      - model_name: ssidName
+        tf_name: name
         type: String
         id: true
         description: Ssid Name

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -149,6 +149,7 @@ type YamlConfigAttribute struct {
 	Reference         bool                  `yaml:"reference"`
 	RequiresReplace   bool                  `yaml:"requires_replace"`
 	QueryParam        bool                  `yaml:"query_param"`
+	DeleteQueryParam  bool                  `yaml:"delete_query_param"`
 	DataSourceQuery   bool                  `yaml:"data_source_query"`
 	Mandatory         bool                  `yaml:"mandatory"`
 	WriteOnly         bool                  `yaml:"write_only"`
@@ -259,6 +260,16 @@ func HasQueryParam(attributes []YamlConfigAttribute) bool {
 	return false
 }
 
+// Templating helper function to return true if delete query parameters included in attributes
+func HasDeleteQueryParam(attributes []YamlConfigAttribute) bool {
+	for _, attr := range attributes {
+		if attr.DeleteQueryParam {
+			return true
+		}
+	}
+	return false
+}
+
 // Templating helper function to return the ID attribute
 func GetId(attributes []YamlConfigAttribute) YamlConfigAttribute {
 	for _, attr := range attributes {
@@ -283,6 +294,16 @@ func GetMatchId(attributes []YamlConfigAttribute) YamlConfigAttribute {
 func GetQueryParam(attributes []YamlConfigAttribute) YamlConfigAttribute {
 	for _, attr := range attributes {
 		if attr.QueryParam {
+			return attr
+		}
+	}
+	return YamlConfigAttribute{}
+}
+
+// Templating helper function to return the delete query parameter attribute
+func GetDeleteQueryParam(attributes []YamlConfigAttribute) YamlConfigAttribute {
+	for _, attr := range attributes {
+		if attr.DeleteQueryParam {
 			return attr
 		}
 	}
@@ -431,9 +452,11 @@ var functions = template.FuncMap{
 	"hasId":                 HasId,
 	"hasReference":          HasReference,
 	"hasQueryParam":         HasQueryParam,
+	"hasDeleteQueryParam":   HasDeleteQueryParam,
 	"getId":                 GetId,
 	"getMatchId":            GetMatchId,
 	"getQueryParam":         GetQueryParam,
+	"getDeleteQueryParam":   GetDeleteQueryParam,
 	"hasDataSourceQuery":    HasDataSourceQuery,
 	"firstPathElement":      FirstPathElement,
 	"remainingPathElements": RemainingPathElements,

--- a/gen/schema/schema.yaml
+++ b/gen/schema/schema.yaml
@@ -52,6 +52,7 @@ attribute:
   reference: bool(required=False) # Set to true if the attribute is a reference being used in the path (URL) of the REST endpoint
   requires_replace: bool(required=False) # Set to true if the attribute update forces Terraform to destroy/recreate the entire resource
   query_param: bool(required=False) # Set to true if the attribute is a query parameter and being used for GET, POST and PUT requests
+  delete_query_param: bool(required=False) # Set to true if the attribute is a query parameter and being used for DELETE request. Note: This cannot be used in conjunction with 'delete_id_query_param'
   data_source_query: bool(required=False) # Set to true if the attribute is an alternative query parameter for the data source
   mandatory: bool(required=False) # Set to true if the attribute is mandatory
   write_only: bool(required=False) # Set to true if the attribute is write-only, meaning we cannot read the value

--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -602,6 +602,9 @@ func (r *{{camelCase .Name}}Resource) Delete(ctx context.Context, req resource.D
 	res, err := r.client.Delete({{if .DeleteRestEndpoint}}state.getPathDelete(){{else}}state.getPath(){{end}})
 	{{- else if .DeleteIdQueryParam}}
 	res, err := r.client.Delete({{if .DeleteRestEndpoint}}state.getPathDelete(){{else}}state.getPath(){{end}} + "?{{.DeleteIdQueryParam}}=" + url.QueryEscape(state.Id.ValueString()))
+	{{- else if hasDeleteQueryParam .Attributes}}
+		{{- $deleteQueryParam := getDeleteQueryParam .Attributes}}
+	res, err := r.client.Delete({{if .DeleteRestEndpoint}}state.getPathDelete(){{else}}state.getPath(){{end}} + "?{{$deleteQueryParam.TfName}}=" + url.QueryEscape(state.{{toGoName $deleteQueryParam.TfName}}.Value{{$deleteQueryParam.Type}}()))
 	{{- else}}
 	res, err := r.client.Delete({{if .DeleteRestEndpoint}}state.getPathDelete(){{else}}state.getPath(){{end}} + "/" + url.QueryEscape(state.Id.ValueString()))
 	{{- end}}

--- a/internal/provider/model_catalystcenter_wireless_profile.go
+++ b/internal/provider/model_catalystcenter_wireless_profile.go
@@ -49,16 +49,12 @@ type WirelessProfileSsidDetails struct {
 
 // Section below is generated&owned by "gen/generator.go". //template:begin getPath
 func (data WirelessProfile) getPath() string {
-	return "/dna/intent/api/v1/wireless/profile"
+	return "/dna/intent/api/v2/wireless/profile"
 }
 
 // End of section. //template:end getPath
 
 // Section below is generated&owned by "gen/generator.go". //template:begin getPathDelete
-
-func (data WirelessProfile) getPathDelete() string {
-	return "/dna/intent/api/v1/wireless-profile"
-}
 
 // End of section. //template:end getPathDelete
 
@@ -71,14 +67,14 @@ func (data WirelessProfile) toBody(ctx context.Context, state WirelessProfile) s
 	}
 	_ = put
 	if !data.Name.IsNull() {
-		body, _ = sjson.Set(body, "profileDetails.name", data.Name.ValueString())
+		body, _ = sjson.Set(body, "wirelessProfileName", data.Name.ValueString())
 	}
 	if len(data.SsidDetails) > 0 {
-		body, _ = sjson.Set(body, "profileDetails.ssidDetails", []interface{}{})
+		body, _ = sjson.Set(body, "ssidDetails", []interface{}{})
 		for _, item := range data.SsidDetails {
 			itemBody := ""
 			if !item.Name.IsNull() {
-				itemBody, _ = sjson.Set(itemBody, "name", item.Name.ValueString())
+				itemBody, _ = sjson.Set(itemBody, "ssidName", item.Name.ValueString())
 			}
 			if !item.EnableFabric.IsNull() {
 				itemBody, _ = sjson.Set(itemBody, "enableFabric", item.EnableFabric.ValueBool())
@@ -98,7 +94,7 @@ func (data WirelessProfile) toBody(ctx context.Context, state WirelessProfile) s
 			if !item.PolicyProfileName.IsNull() {
 				itemBody, _ = sjson.Set(itemBody, "policyProfileName", item.PolicyProfileName.ValueString())
 			}
-			body, _ = sjson.SetRaw(body, "profileDetails.ssidDetails.-1", itemBody)
+			body, _ = sjson.SetRaw(body, "ssidDetails.-1", itemBody)
 		}
 	}
 	return body
@@ -108,16 +104,16 @@ func (data WirelessProfile) toBody(ctx context.Context, state WirelessProfile) s
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBody
 func (data *WirelessProfile) fromBody(ctx context.Context, res gjson.Result) {
-	if value := res.Get("0.profileDetails.name"); value.Exists() {
+	if value := res.Get("wirelessProfileName"); value.Exists() {
 		data.Name = types.StringValue(value.String())
 	} else {
 		data.Name = types.StringNull()
 	}
-	if value := res.Get("0.profileDetails.ssidDetails"); value.Exists() && len(value.Array()) > 0 {
+	if value := res.Get("ssidDetails"); value.Exists() && len(value.Array()) > 0 {
 		data.SsidDetails = make([]WirelessProfileSsidDetails, 0)
 		value.ForEach(func(k, v gjson.Result) bool {
 			item := WirelessProfileSsidDetails{}
-			if cValue := v.Get("name"); cValue.Exists() {
+			if cValue := v.Get("ssidName"); cValue.Exists() {
 				item.Name = types.StringValue(cValue.String())
 			} else {
 				item.Name = types.StringNull()
@@ -152,17 +148,17 @@ func (data *WirelessProfile) fromBody(ctx context.Context, res gjson.Result) {
 
 // Section below is generated&owned by "gen/generator.go". //template:begin updateFromBody
 func (data *WirelessProfile) updateFromBody(ctx context.Context, res gjson.Result) {
-	if value := res.Get("0.profileDetails.name"); value.Exists() && !data.Name.IsNull() {
+	if value := res.Get("wirelessProfileName"); value.Exists() && !data.Name.IsNull() {
 		data.Name = types.StringValue(value.String())
 	} else {
 		data.Name = types.StringNull()
 	}
 	for i := range data.SsidDetails {
-		keys := [...]string{"name"}
+		keys := [...]string{"ssidName"}
 		keyValues := [...]string{data.SsidDetails[i].Name.ValueString()}
 
 		var r gjson.Result
-		res.Get("0.profileDetails.ssidDetails").ForEach(
+		res.Get("ssidDetails").ForEach(
 			func(_, v gjson.Result) bool {
 				found := false
 				for ik := range keys {
@@ -180,7 +176,7 @@ func (data *WirelessProfile) updateFromBody(ctx context.Context, res gjson.Resul
 				return true
 			},
 		)
-		if value := r.Get("name"); value.Exists() && !data.SsidDetails[i].Name.IsNull() {
+		if value := r.Get("ssidName"); value.Exists() && !data.SsidDetails[i].Name.IsNull() {
 			data.SsidDetails[i].Name = types.StringValue(value.String())
 		} else {
 			data.SsidDetails[i].Name = types.StringNull()
@@ -212,6 +208,9 @@ func (data *WirelessProfile) updateFromBody(ctx context.Context, res gjson.Resul
 
 // Section below is generated&owned by "gen/generator.go". //template:begin isNull
 func (data *WirelessProfile) isNull(ctx context.Context, res gjson.Result) bool {
+	if !data.Name.IsNull() {
+		return false
+	}
 	if len(data.SsidDetails) > 0 {
 		return false
 	}

--- a/internal/provider/resource_catalystcenter_wireless_profile_test.go
+++ b/internal/provider/resource_catalystcenter_wireless_profile_test.go
@@ -44,6 +44,10 @@ func TestAccCcWirelessProfile(t *testing.T) {
 		Config: testAccCcWirelessProfilePrerequisitesConfig + testAccCcWirelessProfileConfig_all(),
 		Check:  resource.ComposeTestCheckFunc(checks...),
 	})
+	steps = append(steps, resource.TestStep{
+		ResourceName: "catalystcenter_wireless_profile.test",
+		ImportState:  true,
+	})
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -11,6 +11,8 @@ description: |-
 
 - Fix `mfp_client_protection` attribute validation of `catalystcenter_wireless_enterprise_ssid` resource, [link](https://github.com/CiscoDevNet/terraform-provider-catalystcenter/issues/74)
 
+- BREAKING CHANGE: Modified `wireless_profile` resource to use /dna/intent/api/v2/wireless/profile API endpoint, this resource only works with DNAC version 2.3.7.5+
+
 ## 0.1.8
 
 - Fix import functionality for resources with multipart keys, e.g. `catalystcenter_ip_pool_reservation`


### PR DESCRIPTION
BREAKING CHANGE: Modified `wireless_profile` resource to use /dna/intent/api/v2/wireless/profile API endpoint, this resource only works with DNAC version 2.3.7.5+, Fix #73 