### PR TITLE
Fix issue #92 - removed mandatory: true from attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.1.10 (unreleased)
 
+- Fix issue with mandatory attributes in `transit_peer_network` resource, [link](https://github.com/CiscoDevNet/terraform-provider-catalystcenter/issues/92)
 - BREAKING CHANGE: Fix `ip_pool` update if more than 25 pools are registered
 - BREAKING CHANGE: Rename `radio_type_a_power_treshold_v1` attribute of `catalystcenter_wireless_rf_profile` resource to `radio_type_a_power_threshold_v1`
 - BREAKING CHANGE: Rename `radio_type_b_power_treshold_v1` attribute of `catalystcenter_wireless_rf_profile` resource to `radio_type_b_power_threshold_v1`

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -9,6 +9,7 @@ description: |-
 
 ## 0.1.10 (unreleased)
 
+- Fix issue with mandatory attributes in `transit_peer_network` resource, [link](https://github.com/CiscoDevNet/terraform-provider-catalystcenter/issues/92)
 - BREAKING CHANGE: Fix `ip_pool` update if more than 25 pools are registered
 - BREAKING CHANGE: Rename `radio_type_a_power_treshold_v1` attribute of `catalystcenter_wireless_rf_profile` resource to `radio_type_a_power_threshold_v1`
 - BREAKING CHANGE: Rename `radio_type_b_power_treshold_v1` attribute of `catalystcenter_wireless_rf_profile` resource to `radio_type_b_power_threshold_v1`

--- a/docs/resources/transit_peer_network.md
+++ b/docs/resources/transit_peer_network.md
@@ -32,15 +32,15 @@ resource "catalystcenter_transit_peer_network" "example" {
 
 ### Required
 
-- `autonomous_system_number` (String) Autonomous System Number
-- `routing_protocol_name` (String) Routing Protocol Name
-  - Choices: `BGP`
 - `transit_peer_network_name` (String) Transit Peer Network Name
 - `transit_peer_network_type` (String) Transit Peer Network Type
   - Choices: `ip_transit`, `sda_transit_with_lisp_bgp`, `sda_transit_with_pub_sub`
 
 ### Optional
 
+- `autonomous_system_number` (String) Autonomous System Number
+- `routing_protocol_name` (String) Routing Protocol Name
+  - Choices: `BGP`
 - `transit_control_plane_settings` (Attributes List) Transit Control Plane Settings info (see [below for nested schema](#nestedatt--transit_control_plane_settings))
 
 ### Read-Only
@@ -50,7 +50,7 @@ resource "catalystcenter_transit_peer_network" "example" {
 <a id="nestedatt--transit_control_plane_settings"></a>
 ### Nested Schema for `transit_control_plane_settings`
 
-Required:
+Optional:
 
 - `device_management_ip_address` (String) Device Management Ip Address of provisioned device
 - `site_name_hierarchy` (String) Site Name Hierarchy where device is provisioned

--- a/gen/definitions/transit_peer_network.yaml
+++ b/gen/definitions/transit_peer_network.yaml
@@ -24,7 +24,6 @@ attributes:
   - model_name: routingProtocolName
     data_path: ipTransitSettings
     type: String
-    mandatory: true
     requires_replace: true
     description: Routing Protocol Name
     enum_values: [BGP]
@@ -32,7 +31,6 @@ attributes:
   - model_name: autonomousSystemNumber
     data_path: ipTransitSettings
     type: String
-    mandatory: true
     requires_replace: true
     description: Autonomous System Number
     example: "65010"
@@ -45,12 +43,10 @@ attributes:
       - model_name: siteNameHierarchy
         requires_replace: true
         type: String
-        mandatory: true
         description: Site Name Hierarchy where device is provisioned
         example: "Global/Area1"
       - model_name: deviceManagementIpAddress
         requires_replace: true
         type: String
-        mandatory: true
         description: Device Management Ip Address of provisioned device
         example: "10.0.0.1"

--- a/internal/provider/resource_catalystcenter_transit_peer_network.go
+++ b/internal/provider/resource_catalystcenter_transit_peer_network.go
@@ -89,7 +89,7 @@ func (r *TransitPeerNetworkResource) Schema(ctx context.Context, req resource.Sc
 			},
 			"routing_protocol_name": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Routing Protocol Name").AddStringEnumDescription("BGP").String,
-				Required:            true,
+				Optional:            true,
 				Validators: []validator.String{
 					stringvalidator.OneOf("BGP"),
 				},
@@ -99,7 +99,7 @@ func (r *TransitPeerNetworkResource) Schema(ctx context.Context, req resource.Sc
 			},
 			"autonomous_system_number": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Autonomous System Number").String,
-				Required:            true,
+				Optional:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -111,14 +111,14 @@ func (r *TransitPeerNetworkResource) Schema(ctx context.Context, req resource.Sc
 					Attributes: map[string]schema.Attribute{
 						"site_name_hierarchy": schema.StringAttribute{
 							MarkdownDescription: helpers.NewAttributeDescription("Site Name Hierarchy where device is provisioned").String,
-							Required:            true,
+							Optional:            true,
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplace(),
 							},
 						},
 						"device_management_ip_address": schema.StringAttribute{
 							MarkdownDescription: helpers.NewAttributeDescription("Device Management Ip Address of provisioned device").String,
-							Required:            true,
+							Optional:            true,
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplace(),
 							},

--- a/internal/provider/resource_catalystcenter_transit_peer_network_test.go
+++ b/internal/provider/resource_catalystcenter_transit_peer_network_test.go
@@ -61,8 +61,6 @@ func testAccCcTransitPeerNetworkConfig_minimum() string {
 	config := `resource "catalystcenter_transit_peer_network" "test" {` + "\n"
 	config += `	transit_peer_network_name = "TRANSIT_1"` + "\n"
 	config += `	transit_peer_network_type = "ip_transit"` + "\n"
-	config += `	routing_protocol_name = "BGP"` + "\n"
-	config += `	autonomous_system_number = "65010"` + "\n"
 	config += `}` + "\n"
 	return config
 }

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -9,6 +9,7 @@ description: |-
 
 ## 0.1.10 (unreleased)
 
+- Fix issue with mandatory attributes in `transit_peer_network` resource, [link](https://github.com/CiscoDevNet/terraform-provider-catalystcenter/issues/92)
 - BREAKING CHANGE: Fix `ip_pool` update if more than 25 pools are registered
 - BREAKING CHANGE: Rename `radio_type_a_power_treshold_v1` attribute of `catalystcenter_wireless_rf_profile` resource to `radio_type_a_power_threshold_v1`
 - BREAKING CHANGE: Rename `radio_type_b_power_treshold_v1` attribute of `catalystcenter_wireless_rf_profile` resource to `radio_type_b_power_threshold_v1`


### PR DESCRIPTION
Based on docs API schema for this resource looks like this:

![Screenshot 2024-07-03 at 20 48 45](https://github.com/CiscoDevNet/terraform-provider-catalystcenter/assets/132581633/73aab019-3df3-4330-b5ab-51a4ec310d3e)

In resource definition structure of attributes was flatten, so in order to fix issue I had to remove `mandatory: true` from:

routingProtocolName
autonomousSystemNumber

and 

siteNameHierarchy
deviceManagementIpAddress

