### PR TITLE
fix issue #125 by adding limit=1000 to get operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.13 (unreleased)
+
+- Fix issue with catalystcenter_ip_pool forces replacement on `catalystcenter_ip_pool` resource, [link](https://github.com/CiscoDevNet/terraform-provider-catalystcenter/issues/125)
+
 ## 0.1.12
 
 - Change default timeout for asynchronous operations to 60 seconds and introduce provider attribute `max_timeout` to set a custom timeout

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -7,6 +7,10 @@ description: |-
 
 # Changelog
 
+## 0.1.13 (unreleased)
+
+- Fix issue with catalystcenter_ip_pool forces replacement on `catalystcenter_ip_pool` resource, [link](https://github.com/CiscoDevNet/terraform-provider-catalystcenter/issues/125)
+
 ## 0.1.12
 
 - Change default timeout for asynchronous operations to 60 seconds and introduce provider attribute `max_timeout` to set a custom timeout

--- a/gen/definitions/ip_pool.yaml
+++ b/gen/definitions/ip_pool.yaml
@@ -3,6 +3,7 @@ name: IP Pool
 rest_endpoint: /api/v2/ippool
 get_requires_id: true
 id_from_query_path: response
+get_extra_query_params: "?limit=1000"
 doc_category: Network Settings
 attributes:
   - model_name: ipPoolName

--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -451,6 +451,9 @@ func (r *{{camelCase .Name}}Resource) Create(ctx context.Context, req resource.C
 	params += {{$queryParams}}
 		{{- end}}
 		{{- end}}
+	{{- if .GetExtraQueryParams}}
+	params += "{{.GetExtraQueryParams}}"
+	{{- end}}
 	res, err = r.client.Get({{if .GetRestEndpoint}}"{{.GetRestEndpoint}}"{{else}}plan.getPath(){{end}} + params)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object (GET), got error: %s, %s", err, res.String()))

--- a/internal/provider/data_source_catalystcenter_ip_pool.go
+++ b/internal/provider/data_source_catalystcenter_ip_pool.go
@@ -133,7 +133,7 @@ func (d *IPPoolDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Read", config.Id.String()))
 	if config.Id.IsNull() && !config.Name.IsNull() {
-		res, err := d.client.Get(config.getPath())
+		res, err := d.client.Get(config.getPath() + "?limit=1000")
 		if err != nil {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve objects, got error: %s", err))
 			return
@@ -157,6 +157,7 @@ func (d *IPPoolDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 
 	params := ""
 	params += "/" + url.QueryEscape(config.Id.ValueString())
+	params += "?limit=1000"
 	res, err := d.client.Get(config.getPath() + params)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object, got error: %s", err))

--- a/internal/provider/resource_catalystcenter_ip_pool.go
+++ b/internal/provider/resource_catalystcenter_ip_pool.go
@@ -152,6 +152,7 @@ func (r *IPPoolResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 	params = ""
+	params += "?limit=1000"
 	res, err = r.client.Get(plan.getPath() + params)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object (GET), got error: %s, %s", err, res.String()))
@@ -182,6 +183,7 @@ func (r *IPPoolResource) Read(ctx context.Context, req resource.ReadRequest, res
 
 	params := ""
 	params += "/" + url.QueryEscape(state.Id.ValueString())
+	params += "?limit=1000"
 	res, err := r.client.Get(state.getPath() + params)
 	if err != nil && strings.Contains(err.Error(), "StatusCode 404") {
 		resp.State.RemoveResource(ctx)

--- a/internal/provider/resource_catalystcenter_network_profile.go
+++ b/internal/provider/resource_catalystcenter_network_profile.go
@@ -148,6 +148,7 @@ func (r *NetworkProfileResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 	params = ""
+	params += "?populated=true"
 	res, err = r.client.Get(plan.getPath() + params)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object (GET), got error: %s, %s", err, res.String()))

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -7,6 +7,10 @@ description: |-
 
 # Changelog
 
+## 0.1.13 (unreleased)
+
+- Fix issue with catalystcenter_ip_pool forces replacement on `catalystcenter_ip_pool` resource, [link](https://github.com/CiscoDevNet/terraform-provider-catalystcenter/issues/125)
+
 ## 0.1.12
 
 - Change default timeout for asynchronous operations to 60 seconds and introduce provider attribute `max_timeout` to set a custom timeout


### PR DESCRIPTION
GET request on api/v2/ippool endpoint has implicit limit of 25 results. Only 25 pools can be received in response, to fix that extra_query_param was added: ?limit=1000