### PR TITLE
fabric_l3_handoff_ip_transit: Set compute to true on optional values

### DIFF
--- a/internal/provider/resource_catalystcenter_fabric_l3_handoff_ip_transit.go
+++ b/internal/provider/resource_catalystcenter_fabric_l3_handoff_ip_transit.go
@@ -103,6 +103,7 @@ func (r *FabricL3HandoffIPTransitResource) Schema(ctx context.Context, req resou
 			"external_connectivity_ip_pool_name": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("External connectivity ip pool will be used by Catalyst Center to allocate IP address for the connection between the border node and peer").String,
 				Optional:            true,
+				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -131,6 +132,7 @@ func (r *FabricL3HandoffIPTransitResource) Schema(ctx context.Context, req resou
 			"local_ip_address": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Local ipv4 address for the selected virtual network. Enter the IP addresses and subnet mask in the CIDR notation (IP address/prefix-length). Not applicable if you have already provided an external connectivity ip pool name").String,
 				Optional:            true,
+				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -138,6 +140,7 @@ func (r *FabricL3HandoffIPTransitResource) Schema(ctx context.Context, req resou
 			"remote_ip_address": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Remote ipv4 address for the selected virtual network. Enter the IP addresses and subnet mask in the CIDR notation (IP address/prefix-length). Not applicable if you have already provided an external connectivity ip pool name").String,
 				Optional:            true,
+				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -145,6 +148,7 @@ func (r *FabricL3HandoffIPTransitResource) Schema(ctx context.Context, req resou
 			"local_ipv6_address": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Local ipv6 address for the selected virtual network. Enter the IP addresses and subnet mask in the CIDR notation (IP address/prefix-length). Not applicable if you have already provided an external connectivity ip pool name").String,
 				Optional:            true,
+				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -152,6 +156,7 @@ func (r *FabricL3HandoffIPTransitResource) Schema(ctx context.Context, req resou
 			"remote_ipv6_address": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Remote ipv6 address for the selected virtual network. Enter the IP addresses and subnet mask in the CIDR notation (IP address/prefix-length). Not applicable if you have already provided an external connectivity ip pool name").String,
 				Optional:            true,
+				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},


### PR DESCRIPTION
This change sets `Compute: true` on optional values:
- external_connectivity_ip_pool_name
- local_ip_address
- remote_ip_address
- local_ipv6_address
- remote_ipv6_address

Without the compute: true, the resource does not properly handle the "null" value when the variable is not set and tries to change the variable on each tfplan/tfapply.

In Terraform's provider schema, setting Computed: true on an attribute means that the value of this attribute can be "computed" by the provider or underlying infrastructure rather than strictly supplied by the user. When you use Computed: true, Terraform recognizes that this attribute might change or be derived during the apply phase, even if the user doesn’t explicitly set it.

By adding Computed: true or providing a default, Terraform can ignore differences between null and unset values in the plan.