### PR TITLE
add empty input warning to catalystcenter_*_settings resources

### DIFF
--- a/internal/provider/resource_catalystcenter_banner_settings.go
+++ b/internal/provider/resource_catalystcenter_banner_settings.go
@@ -221,8 +221,15 @@ func (r *BannerSettingsResource) Delete(ctx context.Context, req resource.Delete
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Delete", state.Id.ValueString()))
 	res, err := r.client.Put(state.getPath(), "{}")
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to delete object (PUT), got error: %s, %s", err, res.String()))
-		return
+		errorCode := res.Get("response.errorCode").String()
+		if errorCode == "NCND01090" {
+			// Log a warning and continue execution when Empty input - the groupUuid is null or empty
+			failureReason := res.Get("response.failureReason").String()
+			resp.Diagnostics.AddWarning("Empty input Warning", fmt.Sprintf("Empty input detected (error code: %s, reason %s).", errorCode, failureReason))
+		} else {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to delete object (%s), got error: %s, %s", "PUT", err, res.String()))
+			return
+		}
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Delete finished successfully", state.Id.ValueString()))

--- a/internal/provider/resource_catalystcenter_dhcp_settings.go
+++ b/internal/provider/resource_catalystcenter_dhcp_settings.go
@@ -213,8 +213,15 @@ func (r *DHCPSettingsResource) Delete(ctx context.Context, req resource.DeleteRe
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Delete", state.Id.ValueString()))
 	res, err := r.client.Put(state.getPath(), "{}")
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to delete object (PUT), got error: %s, %s", err, res.String()))
-		return
+		errorCode := res.Get("response.errorCode").String()
+		if errorCode == "NCND01090" {
+			// Log a warning and continue execution when Empty input - the groupUuid is null or empty
+			failureReason := res.Get("response.failureReason").String()
+			resp.Diagnostics.AddWarning("Empty input Warning", fmt.Sprintf("Empty input detected (error code: %s, reason %s).", errorCode, failureReason))
+		} else {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to delete object (%s), got error: %s, %s", "PUT", err, res.String()))
+			return
+		}
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Delete finished successfully", state.Id.ValueString()))

--- a/internal/provider/resource_catalystcenter_dns_settings.go
+++ b/internal/provider/resource_catalystcenter_dns_settings.go
@@ -217,8 +217,15 @@ func (r *DNSSettingsResource) Delete(ctx context.Context, req resource.DeleteReq
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Delete", state.Id.ValueString()))
 	res, err := r.client.Put(state.getPath(), "{}")
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to delete object (PUT), got error: %s, %s", err, res.String()))
-		return
+		errorCode := res.Get("response.errorCode").String()
+		if errorCode == "NCND01090" {
+			// Log a warning and continue execution when Empty input - the groupUuid is null or empty
+			failureReason := res.Get("response.failureReason").String()
+			resp.Diagnostics.AddWarning("Empty input Warning", fmt.Sprintf("Empty input detected (error code: %s, reason %s).", errorCode, failureReason))
+		} else {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to delete object (%s), got error: %s, %s", "PUT", err, res.String()))
+			return
+		}
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Delete finished successfully", state.Id.ValueString()))

--- a/internal/provider/resource_catalystcenter_ntp_settings.go
+++ b/internal/provider/resource_catalystcenter_ntp_settings.go
@@ -213,8 +213,15 @@ func (r *NTPSettingsResource) Delete(ctx context.Context, req resource.DeleteReq
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Delete", state.Id.ValueString()))
 	res, err := r.client.Put(state.getPath(), "{}")
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to delete object (PUT), got error: %s, %s", err, res.String()))
-		return
+		errorCode := res.Get("response.errorCode").String()
+		if errorCode == "NCND01090" {
+			// Log a warning and continue execution when Empty input - the groupUuid is null or empty
+			failureReason := res.Get("response.failureReason").String()
+			resp.Diagnostics.AddWarning("Empty input Warning", fmt.Sprintf("Empty input detected (error code: %s, reason %s).", errorCode, failureReason))
+		} else {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to delete object (%s), got error: %s, %s", "PUT", err, res.String()))
+			return
+		}
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Delete finished successfully", state.Id.ValueString()))

--- a/internal/provider/resource_catalystcenter_telemetry_settings.go
+++ b/internal/provider/resource_catalystcenter_telemetry_settings.go
@@ -259,8 +259,15 @@ func (r *TelemetrySettingsResource) Delete(ctx context.Context, req resource.Del
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Delete", state.Id.ValueString()))
 	res, err := r.client.Put(state.getPath(), "{}")
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to delete object (PUT), got error: %s, %s", err, res.String()))
-		return
+		errorCode := res.Get("response.errorCode").String()
+		if errorCode == "NCND01090" {
+			// Log a warning and continue execution when Empty input - the groupUuid is null or empty
+			failureReason := res.Get("response.failureReason").String()
+			resp.Diagnostics.AddWarning("Empty input Warning", fmt.Sprintf("Empty input detected (error code: %s, reason %s).", errorCode, failureReason))
+		} else {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to delete object (%s), got error: %s, %s", "PUT", err, res.String()))
+			return
+		}
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Delete finished successfully", state.Id.ValueString()))


### PR DESCRIPTION
There is undocumented API issue that throws following error:

```
 Failed to delete object (PUT), got error: HTTP Request failed: StatusCode 400, {"response":{"errorCode":"NCND01090","message":"NCND01090: Empty input - the groupUuid is null or
│ empty","href":"/intent/api/v1/sites/4c06e542-8bc8-4c34-988a-b98030e46229/aaaSettings"},"version":"1.0"}
```

when trying to remove settings from Global level.

To bypass this I added following code block under DELETE method:

```
		errorCode := res.Get("response.errorCode").String()
		if errorCode == "NCND01090" {
			// Log a warning and continue execution when Empty input - the groupUuid is null or empty
			failureReason := res.Get("response.failureReason").String()
			resp.Diagnostics.AddWarning("Empty input Warning", fmt.Sprintf("Empty input detected (error code: %s, reason %s).", errorCode, failureReason))
		} else {
			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to delete object (%s), got error: %s, %s", "PUT", err, res.String()))
			return
		}
```
