### PR TITLE
add put url params;

### DIFF
--- a/gen/definitions/fabric_l3_virtual_network.yaml
+++ b/gen/definitions/fabric_l3_virtual_network.yaml
@@ -10,6 +10,7 @@ put_id_include_path: "0.id"
 put_no_id: true
 doc_category: SDA
 mutex: true
+allow_existing_on_create: true
 attributes:
   - model_name: virtualNetworkName
     requires_replace: true

--- a/gen/definitions/ip_pool.yaml
+++ b/gen/definitions/ip_pool.yaml
@@ -5,6 +5,7 @@ get_requires_id: true
 id_from_query_path: response
 get_extra_query_params: "?limit=1000"
 doc_category: Network Settings
+allow_existing_on_create: true
 attributes:
   - model_name: ipPoolName
     tf_name: name

--- a/gen/definitions/ip_pool_reservation.yaml
+++ b/gen/definitions/ip_pool_reservation.yaml
@@ -8,6 +8,7 @@ put_id_query_param: id
 import_no_id: true
 data_source_no_id: true
 doc_category: Network Settings
+allow_existing_on_create: true
 attributes:
   - model_name: siteId
     type: String

--- a/gen/definitions/transit_network.yaml
+++ b/gen/definitions/transit_network.yaml
@@ -9,6 +9,7 @@ put_no_id: true
 put_id_include_path: 0.id
 skip_minimum_test: true
 doc_category: SDA
+allow_existing_on_create: true
 attributes:
   - model_name: name
     type: String

--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -573,6 +573,14 @@ func (r *{{camelCase .Name}}Resource) Create(ctx context.Context, req resource.C
 	if !r.AllowExistingOnCreate  {
 		tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 	} else {
+		params = ""
+		{{- if hasCreateQueryPath .Attributes}}
+		{{- $createQueryPath := getCreateQueryPath .Attributes}}
+		params += "/" + url.QueryEscape(plan.{{toGoName $createQueryPath.TfName}}.Value{{$createQueryPath.Type}}())
+		{{- end}}
+		{{- if .PutIdQueryParam}}
+		params += "?{{.PutIdQueryParam}}=" + url.QueryEscape(plan.Id.ValueString())
+		{{- end}}
 		body = plan.toBody(ctx, {{camelCase .Name}}{Id: plan.Id})
 		{{- if .PostUpdate}}
 		res, err = r.client.Post(plan.getPath() + params, body {{- if .MaxAsyncWaitTime }}, func(r *cc.Req) { r.MaxAsyncWaitTime={{.MaxAsyncWaitTime}} }{{end}}{{- if .Mutex }}, cc.UseMutex{{- end}})

--- a/internal/provider/resource_catalystcenter_area.go
+++ b/internal/provider/resource_catalystcenter_area.go
@@ -122,6 +122,7 @@ func (r *AreaResource) Create(ctx context.Context, req resource.CreateRequest, r
 	if !r.AllowExistingOnCreate {
 		tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 	} else {
+		params = ""
 		body = plan.toBody(ctx, Area{Id: plan.Id})
 		res, err = r.client.Put(plan.getPath()+"/"+url.QueryEscape(plan.Id.ValueString())+params, body)
 		if err != nil {

--- a/internal/provider/resource_catalystcenter_building.go
+++ b/internal/provider/resource_catalystcenter_building.go
@@ -138,6 +138,7 @@ func (r *BuildingResource) Create(ctx context.Context, req resource.CreateReques
 	if !r.AllowExistingOnCreate {
 		tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 	} else {
+		params = ""
 		body = plan.toBody(ctx, Building{Id: plan.Id})
 		res, err = r.client.Put(plan.getPath()+"/"+url.QueryEscape(plan.Id.ValueString())+params, body)
 		if err != nil {

--- a/internal/provider/resource_catalystcenter_fabric_site.go
+++ b/internal/provider/resource_catalystcenter_fabric_site.go
@@ -140,6 +140,7 @@ func (r *FabricSiteResource) Create(ctx context.Context, req resource.CreateRequ
 	if !r.AllowExistingOnCreate {
 		tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 	} else {
+		params = ""
 		body = plan.toBody(ctx, FabricSite{Id: plan.Id})
 		res, err = r.client.Put(plan.getPath()+params, body, cc.UseMutex)
 		if err != nil {

--- a/internal/provider/resource_catalystcenter_floor.go
+++ b/internal/provider/resource_catalystcenter_floor.go
@@ -151,6 +151,7 @@ func (r *FloorResource) Create(ctx context.Context, req resource.CreateRequest, 
 	if !r.AllowExistingOnCreate {
 		tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 	} else {
+		params = ""
 		body = plan.toBody(ctx, Floor{Id: plan.Id})
 		res, err = r.client.Put(plan.getPath()+"/"+url.QueryEscape(plan.Id.ValueString())+params, body)
 		if err != nil {


### PR DESCRIPTION
turn on update_on_create in all simple example resources.
After this change, all resources from simple example + fabric_transits and l3_vn can be succesfully upserted from clear state, even it they already exist in target.