### PR TITLE
dont return null ids from state

### DIFF
--- a/gen/templates/model.go
+++ b/gen/templates/model.go
@@ -470,6 +470,13 @@ func (data *{{camelCase .Name}}) fromBody(ctx context.Context, res gjson.Result)
 
 // Section below is generated&owned by "gen/generator.go". //template:begin updateFromBody
 func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.Result) {
+	{{- $chunkElementName := "" }} 
+	{{- range  .Attributes}}
+	{{- if .MaxElementsInRootList}}
+	{{- $chunkElementName = .TfName }}
+	var final []{{$name}}{{toGoName .TfName}}
+	{{- end}}
+	{{- end}}
 	{{- if .RootList}}
 	{{- range .Attributes}}
 	{{if .ResponseDataPath}}
@@ -647,9 +654,17 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 		{{- end}}
 		{{- end}}
 		{{- end}}
+		{{- if ne $chunkElementName "" }} 
+		if data.{{toGoName $chunkElementName}}[i].Id != types.StringNull() {
+			final = append(final, data.{{toGoName $chunkElementName}}[i])
+		}
+		{{- end}}
 	}
 	{{- end}}
 	{{- end}}
+	{{- end}}
+	{{- if $chunkElementName }} 
+	data.{{toGoName $chunkElementName}} = final
 	{{- end}}
 }
 // End of section. //template:end updateFromBody

--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -508,11 +508,11 @@ func (r *{{camelCase .Name}}Resource) Create(ctx context.Context, req resource.C
 				if r.AllowExistingOnCreate  {
 					tflog.Info(ctx, fmt.Sprintf("Failed to configure object (%s), got error: %s, %s. allow_existing_on_create is true, beginning update", {{- if .PutCreate }} "PUT" {{- else }} "POST" {{- end }}, err, res.String()))
 				} else{
-					resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (%s), got error: %s, %s", {{- if .PutCreate }} "PUT" {{- else }} "POST" {{- end }}, err, res.String()))
+					resp.Diagnostics.AddWarning("Client Error", fmt.Sprintf("Failed to configure object (%s), got error: %s, %s", {{- if .PutCreate }} "PUT" {{- else }} "POST" {{- end }}, err, res.String()))
 					break
 				}
 				{{- else}}
-				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (%s), got error: %s, %s", {{- if .PutCreate }} "PUT" {{- else }} "POST" {{- end }}, err, res.String()))
+				resp.Diagnostics.AddWarning("Client Error", fmt.Sprintf("Failed to configure object (%s), got error: %s, %s", {{- if .PutCreate }} "PUT" {{- else }} "POST" {{- end }}, err, res.String()))
 				break
 				{{- end}}
 			}
@@ -521,12 +521,12 @@ func (r *{{camelCase .Name}}Resource) Create(ctx context.Context, req resource.C
 			if r.AllowExistingOnCreate  {
 				tflog.Info(ctx, fmt.Sprintf("Failed to configure object (%s), got error: %s, %s. allow_existing_on_create is true, beginning update", {{- if .PutCreate }} "PUT" {{- else }} "POST" {{- end }}, err, res.String()))
 			} else{
-				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (%s), got error: %s, %s", {{- if .PutCreate }} "PUT" {{- else }} "POST" {{- end }}, err, res.String()))
-				return
+				resp.Diagnostics.AddWarning("Client Error", fmt.Sprintf("Failed to configure object (%s), got error: %s, %s", {{- if .PutCreate }} "PUT" {{- else }} "POST" {{- end }}, err, res.String()))
+				break
 			}
 			{{- else}}
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (%s), got error: %s, %s", {{- if .PutCreate }} "PUT" {{- else }} "POST" {{- end }}, err, res.String()))
-			return
+			resp.Diagnostics.AddWarning("Client Error", fmt.Sprintf("Failed to configure object (%s), got error: %s, %s", {{- if .PutCreate }} "PUT" {{- else }} "POST" {{- end }}, err, res.String()))
+			break
 			{{- end}}
 		{{- end}}
 		}
@@ -1000,7 +1000,7 @@ func (r *{{camelCase .Name}}Resource) Update(ctx context.Context, req resource.U
 					failureReason := res.Get("response.failureReason").String()
 					resp.Diagnostics.AddWarning("Device Unreachability Warning", fmt.Sprintf("Device unreachability detected (error code: %s, reason %s).", errorCode, failureReason))
 				} else {
-					resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (%s), got error: %s, %s", "POST", err, res.String()))
+					resp.Diagnostics.AddWarning("Client Error", fmt.Sprintf("Failed to configure object (%s), got error: %s, %s", "POST", err, res.String()))
 					break
 				}
 			}
@@ -1185,8 +1185,8 @@ func (r *{{camelCase .Name}}Resource) Update(ctx context.Context, req resource.U
 			params := ""
 			res, err := r.client.Put(plan.getPath()+params, body, cc.UseMutex)
 			if err != nil {
-				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
-				return
+				resp.Diagnostics.AddWarning("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
+				break
 			}
 		}
 		

--- a/internal/provider/model_catalystcenter_anycast_gateways.go
+++ b/internal/provider/model_catalystcenter_anycast_gateways.go
@@ -259,6 +259,7 @@ func (data *AnycastGateways) fromBody(ctx context.Context, res gjson.Result) {
 
 // Section below is generated&owned by "gen/generator.go". //template:begin updateFromBody
 func (data *AnycastGateways) updateFromBody(ctx context.Context, res gjson.Result) {
+	var final []AnycastGatewaysAnycastGateways
 
 	res = res.Get("response")
 	for i := range data.AnycastGateways {
@@ -374,7 +375,11 @@ func (data *AnycastGateways) updateFromBody(ctx context.Context, res gjson.Resul
 		} else {
 			data.AnycastGateways[i].GroupBasedPolicyEnforcementEnabled = types.BoolNull()
 		}
+		if data.AnycastGateways[i].Id != types.StringNull() {
+			final = append(final, data.AnycastGateways[i])
+		}
 	}
+	data.AnycastGateways = final
 }
 
 // End of section. //template:end updateFromBody

--- a/internal/provider/model_catalystcenter_fabric_l3_handoff_ip_transits.go
+++ b/internal/provider/model_catalystcenter_fabric_l3_handoff_ip_transits.go
@@ -209,6 +209,7 @@ func (data *FabricL3HandoffIPTransits) fromBody(ctx context.Context, res gjson.R
 
 // Section below is generated&owned by "gen/generator.go". //template:begin updateFromBody
 func (data *FabricL3HandoffIPTransits) updateFromBody(ctx context.Context, res gjson.Result) {
+	var final []FabricL3HandoffIPTransitsL3Handoffs
 
 	res = res.Get("response")
 	for i := range data.L3Handoffs {
@@ -294,7 +295,11 @@ func (data *FabricL3HandoffIPTransits) updateFromBody(ctx context.Context, res g
 		} else {
 			data.L3Handoffs[i].RemoteIpv6Address = types.StringNull()
 		}
+		if data.L3Handoffs[i].Id != types.StringNull() {
+			final = append(final, data.L3Handoffs[i])
+		}
 	}
+	data.L3Handoffs = final
 }
 
 // End of section. //template:end updateFromBody

--- a/internal/provider/resource_catalystcenter_anycast_gateways.go
+++ b/internal/provider/resource_catalystcenter_anycast_gateways.go
@@ -241,7 +241,7 @@ func (r *AnycastGatewaysResource) Create(ctx context.Context, req resource.Creat
 				failureReason := res.Get("response.failureReason").String()
 				resp.Diagnostics.AddWarning("Device Unreachability Warning", fmt.Sprintf("Device unreachability detected (error code: %s, reason %s).", errorCode, failureReason))
 			} else {
-				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (%s), got error: %s, %s", "POST", err, res.String()))
+				resp.Diagnostics.AddWarning("Client Error", fmt.Sprintf("Failed to configure object (%s), got error: %s, %s", "POST", err, res.String()))
 				break
 			}
 		}
@@ -465,7 +465,7 @@ func (r *AnycastGatewaysResource) Update(ctx context.Context, req resource.Updat
 					failureReason := res.Get("response.failureReason").String()
 					resp.Diagnostics.AddWarning("Device Unreachability Warning", fmt.Sprintf("Device unreachability detected (error code: %s, reason %s).", errorCode, failureReason))
 				} else {
-					resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (%s), got error: %s, %s", "POST", err, res.String()))
+					resp.Diagnostics.AddWarning("Client Error", fmt.Sprintf("Failed to configure object (%s), got error: %s, %s", "POST", err, res.String()))
 					break
 				}
 			}
@@ -541,8 +541,8 @@ func (r *AnycastGatewaysResource) Update(ctx context.Context, req resource.Updat
 			params := ""
 			res, err := r.client.Put(plan.getPath()+params, body, cc.UseMutex)
 			if err != nil {
-				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
-				return
+				resp.Diagnostics.AddWarning("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
+				break
 			}
 		}
 	}

--- a/internal/provider/resource_catalystcenter_fabric_l3_handoff_ip_transits.go
+++ b/internal/provider/resource_catalystcenter_fabric_l3_handoff_ip_transits.go
@@ -209,7 +209,7 @@ func (r *FabricL3HandoffIPTransitsResource) Create(ctx context.Context, req reso
 				failureReason := res.Get("response.failureReason").String()
 				resp.Diagnostics.AddWarning("Device Unreachability Warning", fmt.Sprintf("Device unreachability detected (error code: %s, reason %s).", errorCode, failureReason))
 			} else {
-				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (%s), got error: %s, %s", "POST", err, res.String()))
+				resp.Diagnostics.AddWarning("Client Error", fmt.Sprintf("Failed to configure object (%s), got error: %s, %s", "POST", err, res.String()))
 				break
 			}
 		}
@@ -448,7 +448,7 @@ func (r *FabricL3HandoffIPTransitsResource) Update(ctx context.Context, req reso
 					failureReason := res.Get("response.failureReason").String()
 					resp.Diagnostics.AddWarning("Device Unreachability Warning", fmt.Sprintf("Device unreachability detected (error code: %s, reason %s).", errorCode, failureReason))
 				} else {
-					resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (%s), got error: %s, %s", "POST", err, res.String()))
+					resp.Diagnostics.AddWarning("Client Error", fmt.Sprintf("Failed to configure object (%s), got error: %s, %s", "POST", err, res.String()))
 					break
 				}
 			}
@@ -499,8 +499,8 @@ func (r *FabricL3HandoffIPTransitsResource) Update(ctx context.Context, req reso
 			params := ""
 			res, err := r.client.Put(plan.getPath()+params, body, cc.UseMutex)
 			if err != nil {
-				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
-				return
+				resp.Diagnostics.AddWarning("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
+				break
 			}
 		}
 	}


### PR DESCRIPTION
By saving null ids in state and not returning them in get, we are able to do a partial success with bulk operation (like 20 subresourcess suceeded, but another 15 failed).
+ Return warning + break from bulk chunk loop
