### PR TITLE
Multicast fabric fix

### DIFF
--- a/gen/templates/model.go
+++ b/gen/templates/model.go
@@ -1172,6 +1172,9 @@ for i := range data.{{toGoName .TfName}} {
 			data.{{$list}}[i].{{toGoName .TfName}} = types.{{.Type}}Value(value.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}())
 		} else {{if .DefaultValue}}if data.{{$list}}[i].{{toGoName .TfName}}.Value{{.Type}}() != {{if eq .Type "String"}}"{{end}}{{.DefaultValue}}{{if eq .Type "String"}}"{{end}} {{end}}{
 			data.{{$list}}[i].{{toGoName .TfName}} = types.{{.Type}}Null()
+			{{- if eq .ModelName "id"}}
+			continue
+			{{- end}}
 		}
 	}
 	{{- else if isListSet .}}

--- a/internal/provider/model_catalystcenter_anycast_gateways.go
+++ b/internal/provider/model_catalystcenter_anycast_gateways.go
@@ -419,6 +419,7 @@ func (data *AnycastGateways) fromBodyUnknowns(ctx context.Context, res gjson.Res
 				data.AnycastGateways[i].Id = types.StringValue(value.String())
 			} else {
 				data.AnycastGateways[i].Id = types.StringNull()
+				continue
 			}
 		}
 		if data.AnycastGateways[i].VlanName.IsUnknown() {

--- a/internal/provider/model_catalystcenter_fabric_devices.go
+++ b/internal/provider/model_catalystcenter_fabric_devices.go
@@ -310,6 +310,7 @@ func (data *FabricDevices) fromBodyUnknowns(ctx context.Context, res gjson.Resul
 				data.FabricDevices[i].Id = types.StringValue(value.String())
 			} else {
 				data.FabricDevices[i].Id = types.StringNull()
+				continue
 			}
 		}
 	}

--- a/internal/provider/model_catalystcenter_fabric_l3_handoff_ip_transits.go
+++ b/internal/provider/model_catalystcenter_fabric_l3_handoff_ip_transits.go
@@ -339,6 +339,7 @@ func (data *FabricL3HandoffIPTransits) fromBodyUnknowns(ctx context.Context, res
 				data.L3Handoffs[i].Id = types.StringValue(value.String())
 			} else {
 				data.L3Handoffs[i].Id = types.StringNull()
+				continue
 			}
 		}
 	}

--- a/internal/provider/model_catalystcenter_fabric_multicast_virtual_networks.go
+++ b/internal/provider/model_catalystcenter_fabric_multicast_virtual_networks.go
@@ -403,6 +403,7 @@ func (data *FabricMulticastVirtualNetworks) fromBodyUnknowns(ctx context.Context
 				data.VirtualNetworks[i].Id = types.StringValue(value.String())
 			} else {
 				data.VirtualNetworks[i].Id = types.StringNull()
+				continue
 			}
 		}
 		for ci := range data.VirtualNetworks[i].MulticastRps {

--- a/internal/provider/model_catalystcenter_fabric_port_assignments.go
+++ b/internal/provider/model_catalystcenter_fabric_port_assignments.go
@@ -301,6 +301,7 @@ func (data *FabricPortAssignments) fromBodyUnknowns(ctx context.Context, res gjs
 				data.PortAssignments[i].Id = types.StringValue(value.String())
 			} else {
 				data.PortAssignments[i].Id = types.StringNull()
+				continue
 			}
 		}
 	}

--- a/internal/provider/model_catalystcenter_provision_devices.go
+++ b/internal/provider/model_catalystcenter_provision_devices.go
@@ -211,6 +211,7 @@ func (data *ProvisionDevices) fromBodyUnknowns(ctx context.Context, res gjson.Re
 				data.ProvisionDevices[i].Id = types.StringValue(value.String())
 			} else {
 				data.ProvisionDevices[i].Id = types.StringNull()
+				continue
 			}
 		}
 	}


### PR DESCRIPTION
When element fails to create, provider used to null every other field in plan, which resulted in inconsistent state.
This change fixes this issue