### PR TITLE
fix removal if not found in controller

### DIFF
--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -907,6 +907,10 @@ func (r *{{camelCase .Name}}Resource) Read(ctx context.Context, req resource.Rea
 		{{- else}}
 	res = res.Get("{{.IdFromQueryPath}}.#({{if .IdFromQueryPathAttribute}}{{.IdFromQueryPathAttribute}}{{else}}id{{end}}==\"" + state.Id.ValueString() + "\")")
 		{{- end}}
+	if !res.Exists() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 	{{- end}}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes

--- a/internal/provider/resource_catalystcenter_anchor_group.go
+++ b/internal/provider/resource_catalystcenter_anchor_group.go
@@ -208,6 +208,10 @@ func (r *AnchorGroupResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 	res = res.Get("response.#(id==\"" + state.Id.ValueString() + "\")")
+	if !res.Exists() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
 	if state.isNull(ctx, res) {

--- a/internal/provider/resource_catalystcenter_authentication_policy_server.go
+++ b/internal/provider/resource_catalystcenter_authentication_policy_server.go
@@ -297,6 +297,10 @@ func (r *AuthenticationPolicyServerResource) Read(ctx context.Context, req resou
 		return
 	}
 	res = res.Get("response.#(instanceUuid==\"" + state.Id.ValueString() + "\")")
+	if !res.Exists() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
 	if state.isNull(ctx, res) {

--- a/internal/provider/resource_catalystcenter_credentials_cli.go
+++ b/internal/provider/resource_catalystcenter_credentials_cli.go
@@ -166,6 +166,10 @@ func (r *CredentialsCLIResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 	res = res.Get("response.cliCredential.#(id==\"" + state.Id.ValueString() + "\")")
+	if !res.Exists() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
 	if state.isNull(ctx, res) {

--- a/internal/provider/resource_catalystcenter_credentials_https_read.go
+++ b/internal/provider/resource_catalystcenter_credentials_https_read.go
@@ -169,6 +169,10 @@ func (r *CredentialsHTTPSReadResource) Read(ctx context.Context, req resource.Re
 		return
 	}
 	res = res.Get("response.httpsRead.#(id==\"" + state.Id.ValueString() + "\")")
+	if !res.Exists() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
 	if state.isNull(ctx, res) {

--- a/internal/provider/resource_catalystcenter_credentials_https_write.go
+++ b/internal/provider/resource_catalystcenter_credentials_https_write.go
@@ -169,6 +169,10 @@ func (r *CredentialsHTTPSWriteResource) Read(ctx context.Context, req resource.R
 		return
 	}
 	res = res.Get("response.httpsWrite.#(id==\"" + state.Id.ValueString() + "\")")
+	if !res.Exists() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
 	if state.isNull(ctx, res) {

--- a/internal/provider/resource_catalystcenter_credentials_snmpv2_read.go
+++ b/internal/provider/resource_catalystcenter_credentials_snmpv2_read.go
@@ -158,6 +158,10 @@ func (r *CredentialsSNMPv2ReadResource) Read(ctx context.Context, req resource.R
 		return
 	}
 	res = res.Get("response.snmpV2cRead.#(id==\"" + state.Id.ValueString() + "\")")
+	if !res.Exists() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
 	if state.isNull(ctx, res) {

--- a/internal/provider/resource_catalystcenter_credentials_snmpv2_write.go
+++ b/internal/provider/resource_catalystcenter_credentials_snmpv2_write.go
@@ -158,6 +158,10 @@ func (r *CredentialsSNMPv2WriteResource) Read(ctx context.Context, req resource.
 		return
 	}
 	res = res.Get("response.snmpV2cWrite.#(id==\"" + state.Id.ValueString() + "\")")
+	if !res.Exists() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
 	if state.isNull(ctx, res) {

--- a/internal/provider/resource_catalystcenter_credentials_snmpv3.go
+++ b/internal/provider/resource_catalystcenter_credentials_snmpv3.go
@@ -189,6 +189,10 @@ func (r *CredentialsSNMPv3Resource) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 	res = res.Get("response.snmpV3.#(id==\"" + state.Id.ValueString() + "\")")
+	if !res.Exists() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
 	if state.isNull(ctx, res) {

--- a/internal/provider/resource_catalystcenter_device_replacement.go
+++ b/internal/provider/resource_catalystcenter_device_replacement.go
@@ -329,6 +329,10 @@ func (r *DeviceReplacementResource) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 	res = res.Get("response.#(id==\"" + state.Id.ValueString() + "\")")
+	if !res.Exists() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
 	if state.isNull(ctx, res) {

--- a/internal/provider/resource_catalystcenter_fabric_l2_handoff.go
+++ b/internal/provider/resource_catalystcenter_fabric_l2_handoff.go
@@ -202,6 +202,10 @@ func (r *FabricL2HandoffResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 	res = res.Get("response.#(id==\"" + state.Id.ValueString() + "\")")
+	if !res.Exists() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
 	if state.isNull(ctx, res) {

--- a/internal/provider/resource_catalystcenter_fabric_l3_handoff_ip_transit.go
+++ b/internal/provider/resource_catalystcenter_fabric_l3_handoff_ip_transit.go
@@ -244,6 +244,10 @@ func (r *FabricL3HandoffIPTransitResource) Read(ctx context.Context, req resourc
 		return
 	}
 	res = res.Get("response.#(id==\"" + state.Id.ValueString() + "\")")
+	if !res.Exists() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
 	if state.isNull(ctx, res) {

--- a/internal/provider/resource_catalystcenter_fabric_site.go
+++ b/internal/provider/resource_catalystcenter_fabric_site.go
@@ -183,6 +183,10 @@ func (r *FabricSiteResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 	res = res.Get("response.#(id==\"" + state.Id.ValueString() + "\")")
+	if !res.Exists() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
 	if state.isNull(ctx, res) {

--- a/internal/provider/resource_catalystcenter_global_credential_netconf.go
+++ b/internal/provider/resource_catalystcenter_global_credential_netconf.go
@@ -189,6 +189,10 @@ func (r *GlobalCredentialNETCONFResource) Read(ctx context.Context, req resource
 		return
 	}
 	res = res.Get("response.#(id==\"" + state.Id.ValueString() + "\")")
+	if !res.Exists() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
 	if state.isNull(ctx, res) {

--- a/internal/provider/resource_catalystcenter_ip_pool.go
+++ b/internal/provider/resource_catalystcenter_ip_pool.go
@@ -238,6 +238,10 @@ func (r *IPPoolResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 	res = res.Get("response.#(id==\"" + state.Id.ValueString() + "\")")
+	if !res.Exists() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
 	if state.isNull(ctx, res) {

--- a/internal/provider/resource_catalystcenter_ip_pool_reservation.go
+++ b/internal/provider/resource_catalystcenter_ip_pool_reservation.go
@@ -316,6 +316,10 @@ func (r *IPPoolReservationResource) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 	res = res.Get("response.#(id==\"" + state.Id.ValueString() + "\")")
+	if !res.Exists() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
 	if state.isNull(ctx, res) {

--- a/internal/provider/resource_catalystcenter_role.go
+++ b/internal/provider/resource_catalystcenter_role.go
@@ -161,6 +161,10 @@ func (r *RoleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 	res = res.Get("response.roles.#(roleId==\"" + state.Id.ValueString() + "\")")
+	if !res.Exists() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
 	if state.isNull(ctx, res) {

--- a/internal/provider/resource_catalystcenter_sp_profile.go
+++ b/internal/provider/resource_catalystcenter_sp_profile.go
@@ -161,6 +161,10 @@ func (r *SPProfileResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 	res = res.Get("response.0.value.#(spProfileName==\"" + state.Name.ValueString() + "\")")
+	if !res.Exists() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
 	if state.isNull(ctx, res) {

--- a/internal/provider/resource_catalystcenter_user.go
+++ b/internal/provider/resource_catalystcenter_user.go
@@ -166,6 +166,10 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 	res = res.Get("response.users.#(userId==\"" + state.Id.ValueString() + "\")")
+	if !res.Exists() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
 	if state.isNull(ctx, res) {

--- a/internal/provider/resource_catalystcenter_wireless_ssid.go
+++ b/internal/provider/resource_catalystcenter_wireless_ssid.go
@@ -500,6 +500,10 @@ func (r *WirelessSSIDResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 	res = res.Get("response.#(id==\"" + state.Id.ValueString() + "\")")
+	if !res.Exists() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// If every attribute is set to null we are dealing with an import operation and therefore reading all attributes
 	if state.isNull(ctx, res) {


### PR DESCRIPTION
If we are getting resource without using id endpoint, we fail to remove it from state if it doesnt exist in controller (as it never throws 404, its just not in reponse list). 
This PR fixes this scenario.