### PR TITLE
Provision devices filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 0.5.11 (unreleased)
 
-- Add `catalystcenter_device_replacement` data source
+- Add `catalystcenter_device_replacement` data source for querying device replacement status
 - Add `catalystcenter_wireless_profile_policy_tag` resource and data source for managing Policy Tags associated with Wireless Profiles (controls which AP Zones are active at specific sites)
+- Fix `catalystcenter_provision_devices` resource to skip reprovisioning devices that are not in the Terraform plan
 
 ## 0.5.10
 

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -9,8 +9,9 @@ description: |-
 
 ## 0.5.11 (unreleased)
 
-- Add `catalystcenter_device_replacement` data source
+- Add `catalystcenter_device_replacement` data source for querying device replacement status
 - Add `catalystcenter_wireless_profile_policy_tag` resource and data source for managing Policy Tags associated with Wireless Profiles (controls which AP Zones are active at specific sites)
+- Fix `catalystcenter_provision_devices` resource to skip reprovisioning devices that are not in the Terraform plan
 
 ## 0.5.10
 

--- a/internal/provider/resource_catalystcenter_provision_devices.go
+++ b/internal/provider/resource_catalystcenter_provision_devices.go
@@ -217,6 +217,21 @@ func (r *ProvisionDevicesResource) Create(ctx context.Context, req resource.Crea
 						return true
 					})
 
+					// Filter: only keep devices that are in the original plan to avoid reprovisioning unrelated devices
+					plannedDeviceIds := make(map[string]bool)
+					for _, planDev := range originalList {
+						plannedDeviceIds[planDev.NetworkDeviceId.ValueString()] = true
+					}
+					var filteredDevices []ProvisionDevicesProvisionDevices
+					for _, dev := range devices {
+						if plannedDeviceIds[dev.NetworkDeviceId.ValueString()] {
+							filteredDevices = append(filteredDevices, dev)
+						} else {
+							tflog.Debug(ctx, fmt.Sprintf("%s: Filtering out device %s from reprovision - not in plan", plan.Id.ValueString(), dev.NetworkDeviceId.ValueString()))
+						}
+					}
+					devices = filteredDevices
+
 					if len(devices) == 0 {
 						resp.Diagnostics.AddError("No Devices Found", fmt.Sprintf("No provisioned devices found for site %s", plan.SiteId.ValueString()))
 						return

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -9,8 +9,9 @@ description: |-
 
 ## 0.5.11 (unreleased)
 
-- Add `catalystcenter_device_replacement` data source
+- Add `catalystcenter_device_replacement` data source for querying device replacement status
 - Add `catalystcenter_wireless_profile_policy_tag` resource and data source for managing Policy Tags associated with Wireless Profiles (controls which AP Zones are active at specific sites)
+- Fix `catalystcenter_provision_devices` resource to skip reprovisioning devices that are not in the Terraform plan
 
 ## 0.5.10
 


### PR DESCRIPTION
Do not reprovision devices that are not in the plan in branched logic.