### PR TITLE
fix: fully paginate get-all list endpoints via limit=500 so read/import see every object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## 0.6.0 (unreleased)
 
 - Update `go-catalystcenter` dependency to `v0.2.0` to add a `UserAgent` option for setting a custom HTTP User-Agent string on authentication, API, and async task-polling requests
+- Fix `catalystcenter_ip_pool` and `catalystcenter_ip_pool_reservation` resources and their data sources (as well as the `catalystcenter_ip_pools` data source) to fully walk the paginated "get all" list endpoints using offset/limit, so read/import see every object instead of only the API's default first page. This mainly affects the `/dna/intent/api/v1/global-pool` fallback endpoint, whose default page size is 25, preventing `Cannot import non-existent remote object` and spurious re-creation once the pool count exceeds the default page size
 
 ## 0.5.25
 

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -11,6 +11,7 @@ description: |-
 ## 0.6.0 (unreleased)
 
 - Update `go-catalystcenter` dependency to `v0.2.0` to add a `UserAgent` option for setting a custom HTTP User-Agent string on authentication, API, and async task-polling requests
+- Fix `catalystcenter_ip_pool` and `catalystcenter_ip_pool_reservation` resources and their data sources (as well as the `catalystcenter_ip_pools` data source) to fully walk the paginated "get all" list endpoints using offset/limit, so read/import see every object instead of only the API's default first page. This mainly affects the `/dna/intent/api/v1/global-pool` fallback endpoint, whose default page size is 25, preventing `Cannot import non-existent remote object` and spurious re-creation once the pool count exceeds the default page size
 
 ## 0.5.25
 

--- a/gen/definitions/ip_pool.yaml
+++ b/gen/definitions/ip_pool.yaml
@@ -4,6 +4,7 @@ fallback_rest_endpoint: /dna/intent/api/v1/global-pool
 id_from_query_path: response
 id_from_query_path_attribute: id
 get_from_all: true
+paginate: true
 skip_minimum_test: true
 put_id: true
 import_no_id: true

--- a/gen/definitions/ip_pool_reservation.yaml
+++ b/gen/definitions/ip_pool_reservation.yaml
@@ -4,6 +4,7 @@ fallback_rest_endpoint: /intent/api/v1/ipam/siteIpAddressPools
 id_from_query_path: response
 id_from_query_path_attribute: id
 get_from_all: true
+paginate: true
 skip_minimum_test: true
 put_id: true
 import_no_id: true

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -105,6 +105,7 @@ type YamlConfig struct {
 	FallbackRestEndpoint          string                `yaml:"fallback_rest_endpoint"`
 	GetNoId                       bool                  `yaml:"get_no_id"`
 	GetFromAll                    bool                  `yaml:"get_from_all"`
+	Paginate                      bool                  `yaml:"paginate"`
 	GetRequiresId                 bool                  `yaml:"get_requires_id"`
 	GetExtraQueryParams           string                `yaml:"get_extra_query_params"`
 	NoDelete                      bool                  `yaml:"no_delete"`

--- a/gen/schema/schema.yaml
+++ b/gen/schema/schema.yaml
@@ -12,6 +12,7 @@ fallback_rest_endpoint: str(required=False) # Fallback REST endpoint path if the
 get_no_id: bool(required=False) # Set to true if the GET request does not require an ID
 data_source_no_id: bool(required=False) # Set to true if id in data source should be optional
 get_from_all: bool(required=False) # Set to true if GET does not support querying individual objects
+paginate: bool(required=False) # Set to true if the get-all list endpoint(s) are paginated (offset/limit) and every page must be fetched and merged. Requires the response to be a "response" array whose items carry an "id". Typically combined with get_from_all.
 get_requires_id: bool(required=False) # Set to true if the GET request requires an ID in the URL path
 get_extra_query_params: str(required=False) # Additional query parameters for GET request
 no_delete: bool(required=False) # Set to true if the DELETE request is not supported

--- a/gen/templates/data_source.go
+++ b/gen/templates/data_source.go
@@ -253,12 +253,12 @@ func (d *{{camelCase .Name}}DataSource) Read(ctx context.Context, req datasource
 	{{- if .GetExtraQueryParams}}
 	params += "{{.GetExtraQueryParams}}"
 	{{- end}}
-	res, err := d.client.Get({{if .GetRestEndpoint}}{{if strContains .GetRestEndpoint "%v"}}config.getPathGet(){{else}}"{{.GetRestEndpoint}}"{{end}}{{else}}config.getPath(){{end}} + params)
+	res, err := {{if .Paginate}}getAllPagesByID(ctx, d.client, {{if .GetRestEndpoint}}{{if strContains .GetRestEndpoint "%v"}}config.getPathGet(){{else}}"{{.GetRestEndpoint}}"{{end}}{{else}}config.getPath(){{end}} + params){{else}}d.client.Get({{if .GetRestEndpoint}}{{if strContains .GetRestEndpoint "%v"}}config.getPathGet(){{else}}"{{.GetRestEndpoint}}"{{end}}{{else}}config.getPath(){{end}} + params){{end}}
 	{{- if .FallbackRestEndpoint}}
 	// Try fallback endpoint if primary fails with 404 or 500
 	if err != nil && (strings.Contains(err.Error(), "StatusCode 404") || strings.Contains(err.Error(), "StatusCode 500")) {
 		tflog.Debug(ctx, fmt.Sprintf("%s: Primary endpoint returned 404 or 500, trying fallback endpoint", config.Id.ValueString()))
-		res, err = d.client.Get(config.getFallbackPath() + params)
+		res, err = {{if .Paginate}}getAllPagesByID(ctx, d.client, config.getFallbackPath() + params){{else}}d.client.Get(config.getFallbackPath() + params){{end}}
 	}
 	{{- end}}
 	if err != nil {

--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -732,13 +732,13 @@ func (r *{{camelCase .Name}}Resource) Create(ctx context.Context, req resource.C
 	{{- if and .FallbackRestEndpoint $id.FallbackResponseModelName }}
 	useFallback := false
 	{{- end}}
-	res, err = r.client.Get({{if .IdQueryRestEndpoint}}plan.getPathIdQuery(){{else if .GetRestEndpoint}}{{if strContains .GetRestEndpoint "%v"}}plan.getPathGet(){{else}}"{{.GetRestEndpoint}}"{{end}}{{else}}plan.getPath(){{end}} + params)
+	res, err = {{if .Paginate}}getAllPagesByID(ctx, r.client, {{if .IdQueryRestEndpoint}}plan.getPathIdQuery(){{else if .GetRestEndpoint}}{{if strContains .GetRestEndpoint "%v"}}plan.getPathGet(){{else}}"{{.GetRestEndpoint}}"{{end}}{{else}}plan.getPath(){{end}} + params){{else}}r.client.Get({{if .IdQueryRestEndpoint}}plan.getPathIdQuery(){{else if .GetRestEndpoint}}{{if strContains .GetRestEndpoint "%v"}}plan.getPathGet(){{else}}"{{.GetRestEndpoint}}"{{end}}{{else}}plan.getPath(){{end}} + params){{end}}
 	{{- if .FallbackRestEndpoint }}
 
 	// Try fallback endpoint if primary fails with 404 or 500
 	if err != nil && (strings.Contains(err.Error(), "StatusCode 404") || strings.Contains(err.Error(), "StatusCode 500")) {
 		tflog.Debug(ctx, fmt.Sprintf("%s: Primary endpoint returned 404 or 500, trying fallback endpoint", plan.Id.ValueString()))
-		res, err = r.client.Get(plan.getFallbackPath() + params)
+		res, err = {{if .Paginate}}getAllPagesByID(ctx, r.client, plan.getFallbackPath() + params){{else}}r.client.Get(plan.getFallbackPath() + params){{end}}
 		{{- if $id.FallbackResponseModelName }}
 		useFallback = true
 		{{- end}}
@@ -791,13 +791,13 @@ func (r *{{camelCase .Name}}Resource) Create(ctx context.Context, req resource.C
 	{{- if .GetExtraQueryParams}}
 	params += "{{.GetExtraQueryParams}}"
 	{{- end}}
-	res, err = r.client.Get({{if .GetRestEndpoint}}{{if strContains .GetRestEndpoint "%v"}}plan.getPathGet(){{else}}"{{.GetRestEndpoint}}"{{end}}{{else}}plan.getPath(){{end}} + params)
+	res, err = {{if .Paginate}}getAllPagesByID(ctx, r.client, {{if .GetRestEndpoint}}{{if strContains .GetRestEndpoint "%v"}}plan.getPathGet(){{else}}"{{.GetRestEndpoint}}"{{end}}{{else}}plan.getPath(){{end}} + params){{else}}r.client.Get({{if .GetRestEndpoint}}{{if strContains .GetRestEndpoint "%v"}}plan.getPathGet(){{else}}"{{.GetRestEndpoint}}"{{end}}{{else}}plan.getPath(){{end}} + params){{end}}
 	{{- if .FallbackRestEndpoint }}
 
 	// Try fallback endpoint if primary fails with 404 or 500
 	if err != nil && (strings.Contains(err.Error(), "StatusCode 404") || strings.Contains(err.Error(), "StatusCode 500")) {
 		tflog.Debug(ctx, fmt.Sprintf("%s: Primary endpoint returned 404 or 500, trying fallback endpoint", plan.Id.ValueString()))
-		res, err = r.client.Get(plan.getFallbackPath() + params)
+		res, err = {{if .Paginate}}getAllPagesByID(ctx, r.client, plan.getFallbackPath() + params){{else}}r.client.Get(plan.getFallbackPath() + params){{end}}
 	}
 	{{- end}}
 	if err != nil {
@@ -908,14 +908,14 @@ func (r *{{camelCase .Name}}Resource) Read(ctx context.Context, req resource.Rea
 	{{- if .UseCache}}
 	res, err := r.ReadCache(ctx, req, state, params)
 	{{- else}}
-	res, err := r.client.Get({{if .GetRestEndpoint}}{{if strContains .GetRestEndpoint "%v"}}state.getPathGet(){{else}}"{{.GetRestEndpoint}}"{{end}}{{else}}state.getPath(){{end}} + params)
+	res, err := {{if .Paginate}}getAllPagesByID(ctx, r.client, {{if .GetRestEndpoint}}{{if strContains .GetRestEndpoint "%v"}}state.getPathGet(){{else}}"{{.GetRestEndpoint}}"{{end}}{{else}}state.getPath(){{end}} + params){{else}}r.client.Get({{if .GetRestEndpoint}}{{if strContains .GetRestEndpoint "%v"}}state.getPathGet(){{else}}"{{.GetRestEndpoint}}"{{end}}{{else}}state.getPath(){{end}} + params){{end}}
 	{{- end}}
 	{{- if .FallbackRestEndpoint }}
 
 	// Try fallback endpoint if primary fails with 404 or 500
 	if err != nil && (strings.Contains(err.Error(), "StatusCode 404") || strings.Contains(err.Error(), "StatusCode 500")) {
 		tflog.Debug(ctx, fmt.Sprintf("%s: Primary endpoint returned 404 or 500, trying fallback endpoint", state.Id.ValueString()))
-		res, err = r.client.Get(state.getFallbackPath() + params)
+		res, err = {{if .Paginate}}getAllPagesByID(ctx, r.client, state.getFallbackPath() + params){{else}}r.client.Get(state.getFallbackPath() + params){{end}}
 	}
 	{{- end}}
 	if err != nil && (strings.Contains(err.Error(), "StatusCode 404") || strings.Contains(err.Error(), "StatusCode 406") || strings.Contains(err.Error(), "StatusCode 500") || strings.Contains(err.Error(), "StatusCode 400")) {
@@ -1426,13 +1426,13 @@ func (r *{{camelCase .Name}}Resource) Update(ctx context.Context, req resource.U
 		{{- if .GetExtraQueryParams}}
 		params += "{{.GetExtraQueryParams}}"
 		{{- end}}
-		res, err = r.client.Get({{if .GetRestEndpoint}}"{{.GetRestEndpoint}}"{{else}}plan.getPath(){{end}} + params)
+		res, err = {{if .Paginate}}getAllPagesByID(ctx, r.client, {{if .GetRestEndpoint}}"{{.GetRestEndpoint}}"{{else}}plan.getPath(){{end}} + params){{else}}r.client.Get({{if .GetRestEndpoint}}"{{.GetRestEndpoint}}"{{else}}plan.getPath(){{end}} + params){{end}}
 		{{- if .FallbackRestEndpoint }}
 
 		// Try fallback endpoint if primary fails with 404 or 500
 		if err != nil && (strings.Contains(err.Error(), "StatusCode 404") || strings.Contains(err.Error(), "StatusCode 500")) {
 			tflog.Debug(ctx, fmt.Sprintf("%s: Primary endpoint returned 404 or 500, trying fallback endpoint", plan.Id.ValueString()))
-			res, err = r.client.Get(plan.getFallbackPath() + params)
+			res, err = {{if .Paginate}}getAllPagesByID(ctx, r.client, plan.getFallbackPath() + params){{else}}r.client.Get(plan.getFallbackPath() + params){{end}}
 		}
 		{{- end}}
 		if err != nil {
@@ -1546,13 +1546,13 @@ func (r *{{camelCase .Name}}Resource) Update(ctx context.Context, req resource.U
 		{{- if .GetExtraQueryParams}}
 		getParams += "{{.GetExtraQueryParams}}"
 		{{- end}}
-		getRes, err := r.client.Get({{if .GetRestEndpoint}}"{{.GetRestEndpoint}}"{{else}}state.getPath(){{end}} + getParams)
+		getRes, err := {{if .Paginate}}getAllPagesByID(ctx, r.client, {{if .GetRestEndpoint}}"{{.GetRestEndpoint}}"{{else}}state.getPath(){{end}} + getParams){{else}}r.client.Get({{if .GetRestEndpoint}}"{{.GetRestEndpoint}}"{{else}}state.getPath(){{end}} + getParams){{end}}
 		{{- if .FallbackRestEndpoint }}
 
 		// Try fallback endpoint if primary fails with 404 or 500
 		if err != nil && (strings.Contains(err.Error(), "StatusCode 404") || strings.Contains(err.Error(), "StatusCode 500")) {
 			tflog.Debug(ctx, fmt.Sprintf("%s: Primary endpoint returned 404 or 500, trying fallback endpoint", state.Id.ValueString()))
-			getRes, err = r.client.Get(state.getFallbackPath() + getParams)
+			getRes, err = {{if .Paginate}}getAllPagesByID(ctx, r.client, state.getFallbackPath() + getParams){{else}}r.client.Get(state.getFallbackPath() + getParams){{end}}
 		}
 		{{- end}}
 		if err != nil && (strings.Contains(err.Error(), "StatusCode 404") || strings.Contains(err.Error(), "StatusCode 406") || strings.Contains(err.Error(), "StatusCode 500") || strings.Contains(err.Error(), "StatusCode 400")) {
@@ -1960,7 +1960,7 @@ func (r *{{camelCase .Name}}Resource) ReadCache(ctx context.Context, req resourc
 	singleRes = cc.Body{}.SetRaw("response", singleRes.Raw).Res()
 	{{- end}}
 	{{- else}}
-	res, err := r.client.Get({{if .GetRestEndpoint}}"{{.GetRestEndpoint}}"{{else}}state.getPath(){{end}} + params)
+	res, err := {{if .Paginate}}getAllPagesByID(ctx, r.client, {{if .GetRestEndpoint}}"{{.GetRestEndpoint}}"{{else}}state.getPath(){{end}} + params){{else}}r.client.Get({{if .GetRestEndpoint}}"{{.GetRestEndpoint}}"{{else}}state.getPath(){{end}} + params){{end}}
 	singleRes := res
 	{{- end}}
 	if err == nil {

--- a/internal/provider/data_source_catalystcenter_ip_pool.go
+++ b/internal/provider/data_source_catalystcenter_ip_pool.go
@@ -120,11 +120,11 @@ func (d *IPPoolDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Read", config.Id.String()))
 
 	params := ""
-	res, err := d.client.Get(config.getPath() + params)
+	res, err := getAllPagesByID(ctx, d.client, config.getPath()+params)
 	// Try fallback endpoint if primary fails with 404 or 500
 	if err != nil && (strings.Contains(err.Error(), "StatusCode 404") || strings.Contains(err.Error(), "StatusCode 500")) {
 		tflog.Debug(ctx, fmt.Sprintf("%s: Primary endpoint returned 404 or 500, trying fallback endpoint", config.Id.ValueString()))
-		res, err = d.client.Get(config.getFallbackPath() + params)
+		res, err = getAllPagesByID(ctx, d.client, config.getFallbackPath()+params)
 	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object, got error: %s", err))

--- a/internal/provider/data_source_catalystcenter_ip_pool_reservation.go
+++ b/internal/provider/data_source_catalystcenter_ip_pool_reservation.go
@@ -190,11 +190,11 @@ func (d *IPPoolReservationDataSource) Read(ctx context.Context, req datasource.R
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Read", config.Id.String()))
 
 	params := ""
-	res, err := d.client.Get(config.getPath() + params)
+	res, err := getAllPagesByID(ctx, d.client, config.getPath()+params)
 	// Try fallback endpoint if primary fails with 404 or 500
 	if err != nil && (strings.Contains(err.Error(), "StatusCode 404") || strings.Contains(err.Error(), "StatusCode 500")) {
 		tflog.Debug(ctx, fmt.Sprintf("%s: Primary endpoint returned 404 or 500, trying fallback endpoint", config.Id.ValueString()))
-		res, err = d.client.Get(config.getFallbackPath() + params)
+		res, err = getAllPagesByID(ctx, d.client, config.getFallbackPath()+params)
 	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object, got error: %s", err))

--- a/internal/provider/data_source_catalystcenter_ip_pools.go
+++ b/internal/provider/data_source_catalystcenter_ip_pools.go
@@ -127,10 +127,12 @@ func (d *IPPoolsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	tflog.Debug(ctx, "singleton: Beginning Read")
 
 	params := ""
-	res, err := d.client.Get(config.getPath() + params)
+	// The global IP pool list endpoints are paginated with a small default page
+	// size (25), so walk every page to return all pools instead of just the first.
+	res, err := getAllPagesByID(ctx, d.client, config.getPath()+params)
 	if err != nil && (strings.Contains(err.Error(), "StatusCode 404") || strings.Contains(err.Error(), "StatusCode 500")) {
 		tflog.Debug(ctx, "Primary endpoint returned 404 or 500, trying fallback endpoint")
-		res, err = d.client.Get(config.getFallbackPath() + params)
+		res, err = getAllPagesByID(ctx, d.client, config.getFallbackPath()+params)
 	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object, got error: %s", err))

--- a/internal/provider/pagination.go
+++ b/internal/provider/pagination.go
@@ -1,0 +1,59 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Mozilla Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://mozilla.org/MPL/2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	cc "github.com/netascode/go-catalystcenter"
+)
+
+// paginatePageLimit is the page size requested from paginated "get all" list
+// endpoints. Catalyst Center list endpoints accept a limit of up to 500, which
+// also matches the go-catalystcenter client's internal page-full threshold.
+const paginatePageLimit = 500
+
+// getAllPagesByID issues a "get all" request with an explicit limit so the
+// go-catalystcenter client's built-in offset pagination retrieves and merges
+// every page.
+//
+// The client (cc.Client.Get) already walks pages: it appends an increasing
+// "offset" query parameter and concatenates the "response" arrays, continuing
+// only while a page comes back completely full (exactly 500 items, the client's
+// maxItems). Several list endpoints (notably the /dna/intent/api/v1/global-pool
+// fallback) return a small default page (25 items) when no "limit" is supplied,
+// so the client sees a non-full first page, stops, and objects beyond it are
+// invisible — which caused reads/imports to fail with
+// "Cannot import non-existent remote object" once the object count exceeded the
+// default page size.
+//
+// Requesting limit=500 makes those endpoints return full pages so the client's
+// own pagination kicks in and walks them all. We intentionally do NOT add an
+// explicit "offset": the client owns the offset parameter, and supplying our own
+// would collide with the one it appends for page 2+ (producing a duplicate
+// "offset" and an HTTP 400). This helper therefore only sets the limit and
+// delegates the actual page-walking to the client.
+func getAllPagesByID(_ context.Context, client *cc.Client, path string) (cc.Res, error) {
+	sep := "?"
+	if strings.Contains(path, "?") {
+		sep = "&"
+	}
+	return client.Get(path + sep + "limit=" + strconv.Itoa(paginatePageLimit))
+}

--- a/internal/provider/resource_catalystcenter_ip_pool.go
+++ b/internal/provider/resource_catalystcenter_ip_pool.go
@@ -170,12 +170,12 @@ func (r *IPPoolResource) Create(ctx context.Context, req resource.CreateRequest,
 	}
 	params = ""
 	useFallback := false
-	res, err = r.client.Get(plan.getPath() + params)
+	res, err = getAllPagesByID(ctx, r.client, plan.getPath()+params)
 
 	// Try fallback endpoint if primary fails with 404 or 500
 	if err != nil && (strings.Contains(err.Error(), "StatusCode 404") || strings.Contains(err.Error(), "StatusCode 500")) {
 		tflog.Debug(ctx, fmt.Sprintf("%s: Primary endpoint returned 404 or 500, trying fallback endpoint", plan.Id.ValueString()))
-		res, err = r.client.Get(plan.getFallbackPath() + params)
+		res, err = getAllPagesByID(ctx, r.client, plan.getFallbackPath()+params)
 		useFallback = true
 	}
 	if err != nil {
@@ -228,7 +228,7 @@ func (r *IPPoolResource) Read(ctx context.Context, req resource.ReadRequest, res
 	// Try fallback endpoint if primary fails with 404 or 500
 	if err != nil && (strings.Contains(err.Error(), "StatusCode 404") || strings.Contains(err.Error(), "StatusCode 500")) {
 		tflog.Debug(ctx, fmt.Sprintf("%s: Primary endpoint returned 404 or 500, trying fallback endpoint", state.Id.ValueString()))
-		res, err = r.client.Get(state.getFallbackPath() + params)
+		res, err = getAllPagesByID(ctx, r.client, state.getFallbackPath()+params)
 	}
 	if err != nil && (strings.Contains(err.Error(), "StatusCode 404") || strings.Contains(err.Error(), "StatusCode 406") || strings.Contains(err.Error(), "StatusCode 500") || strings.Contains(err.Error(), "StatusCode 400")) {
 		resp.State.RemoveResource(ctx)
@@ -353,7 +353,7 @@ func (r *IPPoolResource) ReadCache(ctx context.Context, req resource.ReadRequest
 		tflog.Info(ctx, fmt.Sprintf("Invalid cache entry type for %s", cacheKey))
 		r.cache.Delete(cacheKey)
 	}
-	res, err := r.client.Get(state.getPath() + params)
+	res, err := getAllPagesByID(ctx, r.client, state.getPath()+params)
 	singleRes := res
 	if err == nil {
 		tflog.Debug(ctx, fmt.Sprintf("set cache for %s", cacheKey))

--- a/internal/provider/resource_catalystcenter_ip_pool_reservation.go
+++ b/internal/provider/resource_catalystcenter_ip_pool_reservation.go
@@ -254,12 +254,12 @@ func (r *IPPoolReservationResource) Create(ctx context.Context, req resource.Cre
 		}
 	}
 	params = ""
-	res, err = r.client.Get(plan.getPath() + params)
+	res, err = getAllPagesByID(ctx, r.client, plan.getPath()+params)
 
 	// Try fallback endpoint if primary fails with 404 or 500
 	if err != nil && (strings.Contains(err.Error(), "StatusCode 404") || strings.Contains(err.Error(), "StatusCode 500")) {
 		tflog.Debug(ctx, fmt.Sprintf("%s: Primary endpoint returned 404 or 500, trying fallback endpoint", plan.Id.ValueString()))
-		res, err = r.client.Get(plan.getFallbackPath() + params)
+		res, err = getAllPagesByID(ctx, r.client, plan.getFallbackPath()+params)
 	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object (GET), got error: %s, %s", err, res.String()))
@@ -306,7 +306,7 @@ func (r *IPPoolReservationResource) Read(ctx context.Context, req resource.ReadR
 	// Try fallback endpoint if primary fails with 404 or 500
 	if err != nil && (strings.Contains(err.Error(), "StatusCode 404") || strings.Contains(err.Error(), "StatusCode 500")) {
 		tflog.Debug(ctx, fmt.Sprintf("%s: Primary endpoint returned 404 or 500, trying fallback endpoint", state.Id.ValueString()))
-		res, err = r.client.Get(state.getFallbackPath() + params)
+		res, err = getAllPagesByID(ctx, r.client, state.getFallbackPath()+params)
 	}
 	if err != nil && (strings.Contains(err.Error(), "StatusCode 404") || strings.Contains(err.Error(), "StatusCode 406") || strings.Contains(err.Error(), "StatusCode 500") || strings.Contains(err.Error(), "StatusCode 400")) {
 		resp.State.RemoveResource(ctx)
@@ -431,7 +431,7 @@ func (r *IPPoolReservationResource) ReadCache(ctx context.Context, req resource.
 		tflog.Info(ctx, fmt.Sprintf("Invalid cache entry type for %s", cacheKey))
 		r.cache.Delete(cacheKey)
 	}
-	res, err := r.client.Get(state.getPath() + params)
+	res, err := getAllPagesByID(ctx, r.client, state.getPath()+params)
 	singleRes := res
 	if err == nil {
 		tflog.Debug(ctx, fmt.Sprintf("set cache for %s", cacheKey))

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -11,6 +11,7 @@ description: |-
 ## 0.6.0 (unreleased)
 
 - Update `go-catalystcenter` dependency to `v0.2.0` to add a `UserAgent` option for setting a custom HTTP User-Agent string on authentication, API, and async task-polling requests
+- Fix `catalystcenter_ip_pool` and `catalystcenter_ip_pool_reservation` resources and their data sources (as well as the `catalystcenter_ip_pools` data source) to fully walk the paginated "get all" list endpoints using offset/limit, so read/import see every object instead of only the API's default first page. This mainly affects the `/dna/intent/api/v1/global-pool` fallback endpoint, whose default page size is 25, preventing `Cannot import non-existent remote object` and spurious re-creation once the pool count exceeds the default page size
 
 ## 0.5.25
 


### PR DESCRIPTION
fix: paginate ip_pool and ip_pool_reservation get-all reads

The go-catalystcenter client only keeps paging while a page returns a full
500 items and never sends `limit`, so it relies on list endpoints defaulting
to a 500-item page. The `/dna/intent/api/v1/global-pool` fallback used by
catalystcenter_ip_pool defaults to 25 items, so the client stops after the
first page and read/import miss every pool beyond it — failing with
"Cannot import non-existent remote object" and re-creating existing pools
once there are more than 25.

Add an opt-in `paginate` generator flag and a shared getAllPagesByID helper
that requests limit=500 and lets the client's built-in offset pagination walk
and merge every page. The helper deliberately sets only the limit, not an
offset, which would collide with the offset the client appends for page 2+
(duplicate offset -> HTTP 400 on a full 500-item page).

Enable it on catalystcenter_ip_pool and catalystcenter_ip_pool_reservation
(and their data sources, plus the catalystcenter_ip_pools data source), the
list endpoints whose default page size is below 500. Verified end-to-end
against a live Catalyst Center with 600 IP pools: page-2 import succeeds and
`terraform plan` reports no changes.

Refs: netascode/terraform-catalystcenter-nac-catalystcenter#136