### PR TITLE
add limit to fallback get url

### DIFF
--- a/gen/definitions/ip_pool.yaml
+++ b/gen/definitions/ip_pool.yaml
@@ -1,6 +1,6 @@
 name: IP Pool
 rest_endpoint: /dna/intent/api/v1/ipam/globalIpAddressPools
-fallback_rest_endpoint: /dna/intent/api/v1/global-pool
+fallback_rest_endpoint: /dna/intent/api/v1/global-pool?limit=500
 id_from_query_path: response
 id_from_query_path_attribute: id
 get_from_all: true

--- a/internal/provider/model_catalystcenter_ip_pool.go
+++ b/internal/provider/model_catalystcenter_ip_pool.go
@@ -55,7 +55,7 @@ func (data IPPool) getPath() string {
 // Section below is generated&owned by "gen/generator.go". //template:begin getFallbackPath
 
 func (data IPPool) getFallbackPath() string {
-	return "/dna/intent/api/v1/global-pool"
+	return "/dna/intent/api/v1/global-pool?limit=500"
 }
 
 // End of section. //template:end getFallbackPath


### PR DESCRIPTION
while the issue for magic number in go-catalystcenter still exists, this alone fixes the issue with ip pool (the endpoint accepts larger limit)