### PR TITLE
Do not validate write-only secret pairs while their values are unknown

### DIFF
--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -575,14 +575,14 @@ func (r *{{camelCase .Name}}Resource) ValidateConfig(ctx context.Context, req re
 	var woVersion{{$go}} types.Int64
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("{{.TfName}}_wo_version"), &woVersion{{$go}})...)
 	{{- end}}
-	if !legacy{{$go}}.IsNull() && !wo{{$go}}.IsNull() {
+	if !legacy{{$go}}.IsUnknown() && !wo{{$go}}.IsUnknown() && !legacy{{$go}}.IsNull() && !wo{{$go}}.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Only one of `{{.TfName}}` and `{{.TfName}}_wo` can be set.",
 		)
 	}
 	{{- if .WoPairMandatory}}
-	if legacy{{$go}}.IsNull() && wo{{$go}}.IsNull() {
+	if !legacy{{$go}}.IsUnknown() && !wo{{$go}}.IsUnknown() && legacy{{$go}}.IsNull() && wo{{$go}}.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Exactly one of `{{.TfName}}` and `{{.TfName}}_wo` must be set.",
@@ -590,14 +590,14 @@ func (r *{{camelCase .Name}}Resource) ValidateConfig(ctx context.Context, req re
 	}
 	{{- end}}
 	{{- if .WoPairHasVersion}}
-	if !wo{{$go}}.IsNull() && woVersion{{$go}}.IsNull() {
+	if !wo{{$go}}.IsUnknown() && !woVersion{{$go}}.IsUnknown() && !wo{{$go}}.IsNull() && woVersion{{$go}}.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"`{{.TfName}}_wo_version` must be set when `{{.TfName}}_wo` is used. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.",
 		)
 	}
 	{{- end}}
-	if !legacy{{$go}}.IsNull() {
+	if !legacy{{$go}}.IsUnknown() && !legacy{{$go}}.IsNull() {
 		resp.Diagnostics.AddWarning("Attribute Deprecated", "{{.DeprecationMessage}}")
 	}
 	{{- end}}
@@ -613,14 +613,14 @@ func (r *{{camelCase .Name}}Resource) ValidateConfig(ctx context.Context, req re
 			for i := range cfg{{$parentGo}} {
 				{{- range legacyWriteOnlyTFChildren .}}
 				{{- $go := toGoName .TfName}}
-				if !cfg{{$parentGo}}[i].{{$go}}.IsNull() && !cfg{{$parentGo}}[i].{{$go}}Wo.IsNull() {
+				if !cfg{{$parentGo}}[i].{{$go}}.IsUnknown() && !cfg{{$parentGo}}[i].{{$go}}Wo.IsUnknown() && !cfg{{$parentGo}}[i].{{$go}}.IsNull() && !cfg{{$parentGo}}[i].{{$go}}Wo.IsNull() {
 					resp.Diagnostics.AddError(
 						"Invalid Attribute Combination",
 						fmt.Sprintf("Only one of `{{.TfName}}` and `{{.TfName}}_wo` can be set in `{{$parentTf}}` element %d.", i),
 					)
 				}
 				{{- if .WoPairMandatory}}
-				if cfg{{$parentGo}}[i].{{$go}}.IsNull() && cfg{{$parentGo}}[i].{{$go}}Wo.IsNull() {
+				if !cfg{{$parentGo}}[i].{{$go}}.IsUnknown() && !cfg{{$parentGo}}[i].{{$go}}Wo.IsUnknown() && cfg{{$parentGo}}[i].{{$go}}.IsNull() && cfg{{$parentGo}}[i].{{$go}}Wo.IsNull() {
 					resp.Diagnostics.AddError(
 						"Invalid Attribute Combination",
 						fmt.Sprintf("Exactly one of `{{.TfName}}` and `{{.TfName}}_wo` must be set in `{{$parentTf}}` element %d.", i),
@@ -628,14 +628,14 @@ func (r *{{camelCase .Name}}Resource) ValidateConfig(ctx context.Context, req re
 				}
 				{{- end}}
 				{{- if .WoPairHasVersion}}
-				if !cfg{{$parentGo}}[i].{{$go}}Wo.IsNull() && cfg{{$parentGo}}[i].{{$go}}WoVersion.IsNull() {
+				if !cfg{{$parentGo}}[i].{{$go}}Wo.IsUnknown() && !cfg{{$parentGo}}[i].{{$go}}WoVersion.IsUnknown() && !cfg{{$parentGo}}[i].{{$go}}Wo.IsNull() && cfg{{$parentGo}}[i].{{$go}}WoVersion.IsNull() {
 					resp.Diagnostics.AddError(
 						"Invalid Attribute Combination",
 						fmt.Sprintf("`{{.TfName}}_wo_version` must be set when `{{.TfName}}_wo` is used in `{{$parentTf}}` element %d. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.", i),
 					)
 				}
 				{{- end}}
-				if !cfg{{$parentGo}}[i].{{$go}}.IsNull() {
+				if !cfg{{$parentGo}}[i].{{$go}}.IsUnknown() && !cfg{{$parentGo}}[i].{{$go}}.IsNull() {
 					resp.Diagnostics.AddWarning("Attribute Deprecated", fmt.Sprintf("{{.DeprecationMessage}} (`{{$parentTf}}` element %d)", i))
 				}
 				{{- end}}

--- a/internal/provider/resource_catalystcenter_aaa_settings.go
+++ b/internal/provider/resource_catalystcenter_aaa_settings.go
@@ -192,19 +192,19 @@ func (r *AAASettingsResource) ValidateConfig(ctx context.Context, req resource.V
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("network_aaa_shared_secret_wo"), &woNetworkAaaSharedSecret)...)
 	var woVersionNetworkAaaSharedSecret types.Int64
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("network_aaa_shared_secret_wo_version"), &woVersionNetworkAaaSharedSecret)...)
-	if !legacyNetworkAaaSharedSecret.IsNull() && !woNetworkAaaSharedSecret.IsNull() {
+	if !legacyNetworkAaaSharedSecret.IsUnknown() && !woNetworkAaaSharedSecret.IsUnknown() && !legacyNetworkAaaSharedSecret.IsNull() && !woNetworkAaaSharedSecret.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Only one of `network_aaa_shared_secret` and `network_aaa_shared_secret_wo` can be set.",
 		)
 	}
-	if !woNetworkAaaSharedSecret.IsNull() && woVersionNetworkAaaSharedSecret.IsNull() {
+	if !woNetworkAaaSharedSecret.IsUnknown() && !woVersionNetworkAaaSharedSecret.IsUnknown() && !woNetworkAaaSharedSecret.IsNull() && woVersionNetworkAaaSharedSecret.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"`network_aaa_shared_secret_wo_version` must be set when `network_aaa_shared_secret_wo` is used. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.",
 		)
 	}
-	if !legacyNetworkAaaSharedSecret.IsNull() {
+	if !legacyNetworkAaaSharedSecret.IsUnknown() && !legacyNetworkAaaSharedSecret.IsNull() {
 		resp.Diagnostics.AddWarning("Attribute Deprecated", "The `network_aaa_shared_secret` attribute stores the secret in Terraform state. Use `network_aaa_shared_secret_wo` together with `network_aaa_shared_secret_wo_version` instead, which keeps it out of state.")
 	}
 	var legacyClientAaaSharedSecret types.String
@@ -213,19 +213,19 @@ func (r *AAASettingsResource) ValidateConfig(ctx context.Context, req resource.V
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("client_aaa_shared_secret_wo"), &woClientAaaSharedSecret)...)
 	var woVersionClientAaaSharedSecret types.Int64
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("client_aaa_shared_secret_wo_version"), &woVersionClientAaaSharedSecret)...)
-	if !legacyClientAaaSharedSecret.IsNull() && !woClientAaaSharedSecret.IsNull() {
+	if !legacyClientAaaSharedSecret.IsUnknown() && !woClientAaaSharedSecret.IsUnknown() && !legacyClientAaaSharedSecret.IsNull() && !woClientAaaSharedSecret.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Only one of `client_aaa_shared_secret` and `client_aaa_shared_secret_wo` can be set.",
 		)
 	}
-	if !woClientAaaSharedSecret.IsNull() && woVersionClientAaaSharedSecret.IsNull() {
+	if !woClientAaaSharedSecret.IsUnknown() && !woVersionClientAaaSharedSecret.IsUnknown() && !woClientAaaSharedSecret.IsNull() && woVersionClientAaaSharedSecret.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"`client_aaa_shared_secret_wo_version` must be set when `client_aaa_shared_secret_wo` is used. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.",
 		)
 	}
-	if !legacyClientAaaSharedSecret.IsNull() {
+	if !legacyClientAaaSharedSecret.IsUnknown() && !legacyClientAaaSharedSecret.IsNull() {
 		resp.Diagnostics.AddWarning("Attribute Deprecated", "The `client_aaa_shared_secret` attribute stores the secret in Terraform state. Use `client_aaa_shared_secret_wo` together with `client_aaa_shared_secret_wo_version` instead, which keeps it out of state.")
 	}
 }

--- a/internal/provider/resource_catalystcenter_authentication_policy_server.go
+++ b/internal/provider/resource_catalystcenter_authentication_policy_server.go
@@ -307,25 +307,25 @@ func (r *AuthenticationPolicyServerResource) ValidateConfig(ctx context.Context,
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("shared_secret_wo"), &woSharedSecret)...)
 	var woVersionSharedSecret types.Int64
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("shared_secret_wo_version"), &woVersionSharedSecret)...)
-	if !legacySharedSecret.IsNull() && !woSharedSecret.IsNull() {
+	if !legacySharedSecret.IsUnknown() && !woSharedSecret.IsUnknown() && !legacySharedSecret.IsNull() && !woSharedSecret.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Only one of `shared_secret` and `shared_secret_wo` can be set.",
 		)
 	}
-	if legacySharedSecret.IsNull() && woSharedSecret.IsNull() {
+	if !legacySharedSecret.IsUnknown() && !woSharedSecret.IsUnknown() && legacySharedSecret.IsNull() && woSharedSecret.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Exactly one of `shared_secret` and `shared_secret_wo` must be set.",
 		)
 	}
-	if !woSharedSecret.IsNull() && woVersionSharedSecret.IsNull() {
+	if !woSharedSecret.IsUnknown() && !woVersionSharedSecret.IsUnknown() && !woSharedSecret.IsNull() && woVersionSharedSecret.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"`shared_secret_wo_version` must be set when `shared_secret_wo` is used. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.",
 		)
 	}
-	if !legacySharedSecret.IsNull() {
+	if !legacySharedSecret.IsUnknown() && !legacySharedSecret.IsNull() {
 		resp.Diagnostics.AddWarning("Attribute Deprecated", "The `shared_secret` attribute stores the secret in Terraform state. Use `shared_secret_wo` together with `shared_secret_wo_version` instead, which keeps it out of state.")
 	}
 	var legacyMessageKey types.String
@@ -334,19 +334,19 @@ func (r *AuthenticationPolicyServerResource) ValidateConfig(ctx context.Context,
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("message_key_wo"), &woMessageKey)...)
 	var woVersionMessageKey types.Int64
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("message_key_wo_version"), &woVersionMessageKey)...)
-	if !legacyMessageKey.IsNull() && !woMessageKey.IsNull() {
+	if !legacyMessageKey.IsUnknown() && !woMessageKey.IsUnknown() && !legacyMessageKey.IsNull() && !woMessageKey.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Only one of `message_key` and `message_key_wo` can be set.",
 		)
 	}
-	if !woMessageKey.IsNull() && woVersionMessageKey.IsNull() {
+	if !woMessageKey.IsUnknown() && !woVersionMessageKey.IsUnknown() && !woMessageKey.IsNull() && woVersionMessageKey.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"`message_key_wo_version` must be set when `message_key_wo` is used. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.",
 		)
 	}
-	if !legacyMessageKey.IsNull() {
+	if !legacyMessageKey.IsUnknown() && !legacyMessageKey.IsNull() {
 		resp.Diagnostics.AddWarning("Attribute Deprecated", "The `message_key` attribute stores the secret in Terraform state. Use `message_key_wo` together with `message_key_wo_version` instead, which keeps it out of state.")
 	}
 	var legacyEncryptionKey types.String
@@ -355,19 +355,19 @@ func (r *AuthenticationPolicyServerResource) ValidateConfig(ctx context.Context,
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("encryption_key_wo"), &woEncryptionKey)...)
 	var woVersionEncryptionKey types.Int64
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("encryption_key_wo_version"), &woVersionEncryptionKey)...)
-	if !legacyEncryptionKey.IsNull() && !woEncryptionKey.IsNull() {
+	if !legacyEncryptionKey.IsUnknown() && !woEncryptionKey.IsUnknown() && !legacyEncryptionKey.IsNull() && !woEncryptionKey.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Only one of `encryption_key` and `encryption_key_wo` can be set.",
 		)
 	}
-	if !woEncryptionKey.IsNull() && woVersionEncryptionKey.IsNull() {
+	if !woEncryptionKey.IsUnknown() && !woVersionEncryptionKey.IsUnknown() && !woEncryptionKey.IsNull() && woVersionEncryptionKey.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"`encryption_key_wo_version` must be set when `encryption_key_wo` is used. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.",
 		)
 	}
-	if !legacyEncryptionKey.IsNull() {
+	if !legacyEncryptionKey.IsUnknown() && !legacyEncryptionKey.IsNull() {
 		resp.Diagnostics.AddWarning("Attribute Deprecated", "The `encryption_key` attribute stores the secret in Terraform state. Use `encryption_key_wo` together with `encryption_key_wo_version` instead, which keeps it out of state.")
 	}
 	{
@@ -377,40 +377,40 @@ func (r *AuthenticationPolicyServerResource) ValidateConfig(ctx context.Context,
 		var cfgCiscoIseDtos []AuthenticationPolicyServerCiscoIseDtos
 		if diags := req.Config.GetAttribute(ctx, path.Root("cisco_ise_dtos"), &cfgCiscoIseDtos); !diags.HasError() {
 			for i := range cfgCiscoIseDtos {
-				if !cfgCiscoIseDtos[i].Password.IsNull() && !cfgCiscoIseDtos[i].PasswordWo.IsNull() {
+				if !cfgCiscoIseDtos[i].Password.IsUnknown() && !cfgCiscoIseDtos[i].PasswordWo.IsUnknown() && !cfgCiscoIseDtos[i].Password.IsNull() && !cfgCiscoIseDtos[i].PasswordWo.IsNull() {
 					resp.Diagnostics.AddError(
 						"Invalid Attribute Combination",
 						fmt.Sprintf("Only one of `password` and `password_wo` can be set in `cisco_ise_dtos` element %d.", i),
 					)
 				}
-				if cfgCiscoIseDtos[i].Password.IsNull() && cfgCiscoIseDtos[i].PasswordWo.IsNull() {
+				if !cfgCiscoIseDtos[i].Password.IsUnknown() && !cfgCiscoIseDtos[i].PasswordWo.IsUnknown() && cfgCiscoIseDtos[i].Password.IsNull() && cfgCiscoIseDtos[i].PasswordWo.IsNull() {
 					resp.Diagnostics.AddError(
 						"Invalid Attribute Combination",
 						fmt.Sprintf("Exactly one of `password` and `password_wo` must be set in `cisco_ise_dtos` element %d.", i),
 					)
 				}
-				if !cfgCiscoIseDtos[i].PasswordWo.IsNull() && cfgCiscoIseDtos[i].PasswordWoVersion.IsNull() {
+				if !cfgCiscoIseDtos[i].PasswordWo.IsUnknown() && !cfgCiscoIseDtos[i].PasswordWoVersion.IsUnknown() && !cfgCiscoIseDtos[i].PasswordWo.IsNull() && cfgCiscoIseDtos[i].PasswordWoVersion.IsNull() {
 					resp.Diagnostics.AddError(
 						"Invalid Attribute Combination",
 						fmt.Sprintf("`password_wo_version` must be set when `password_wo` is used in `cisco_ise_dtos` element %d. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.", i),
 					)
 				}
-				if !cfgCiscoIseDtos[i].Password.IsNull() {
+				if !cfgCiscoIseDtos[i].Password.IsUnknown() && !cfgCiscoIseDtos[i].Password.IsNull() {
 					resp.Diagnostics.AddWarning("Attribute Deprecated", fmt.Sprintf("The `password` attribute stores the secret in Terraform state. Use `password_wo` together with `password_wo_version` instead, which keeps it out of state. (`cisco_ise_dtos` element %d)", i))
 				}
-				if !cfgCiscoIseDtos[i].Sshkey.IsNull() && !cfgCiscoIseDtos[i].SshkeyWo.IsNull() {
+				if !cfgCiscoIseDtos[i].Sshkey.IsUnknown() && !cfgCiscoIseDtos[i].SshkeyWo.IsUnknown() && !cfgCiscoIseDtos[i].Sshkey.IsNull() && !cfgCiscoIseDtos[i].SshkeyWo.IsNull() {
 					resp.Diagnostics.AddError(
 						"Invalid Attribute Combination",
 						fmt.Sprintf("Only one of `sshkey` and `sshkey_wo` can be set in `cisco_ise_dtos` element %d.", i),
 					)
 				}
-				if !cfgCiscoIseDtos[i].SshkeyWo.IsNull() && cfgCiscoIseDtos[i].SshkeyWoVersion.IsNull() {
+				if !cfgCiscoIseDtos[i].SshkeyWo.IsUnknown() && !cfgCiscoIseDtos[i].SshkeyWoVersion.IsUnknown() && !cfgCiscoIseDtos[i].SshkeyWo.IsNull() && cfgCiscoIseDtos[i].SshkeyWoVersion.IsNull() {
 					resp.Diagnostics.AddError(
 						"Invalid Attribute Combination",
 						fmt.Sprintf("`sshkey_wo_version` must be set when `sshkey_wo` is used in `cisco_ise_dtos` element %d. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.", i),
 					)
 				}
-				if !cfgCiscoIseDtos[i].Sshkey.IsNull() {
+				if !cfgCiscoIseDtos[i].Sshkey.IsUnknown() && !cfgCiscoIseDtos[i].Sshkey.IsNull() {
 					resp.Diagnostics.AddWarning("Attribute Deprecated", fmt.Sprintf("The `sshkey` attribute stores the secret in Terraform state. Use `sshkey_wo` together with `sshkey_wo_version` instead, which keeps it out of state. (`cisco_ise_dtos` element %d)", i))
 				}
 			}

--- a/internal/provider/resource_catalystcenter_credentials_cli.go
+++ b/internal/provider/resource_catalystcenter_credentials_cli.go
@@ -143,25 +143,25 @@ func (r *CredentialsCLIResource) ValidateConfig(ctx context.Context, req resourc
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("password_wo"), &woPassword)...)
 	var woVersionPassword types.Int64
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("password_wo_version"), &woVersionPassword)...)
-	if !legacyPassword.IsNull() && !woPassword.IsNull() {
+	if !legacyPassword.IsUnknown() && !woPassword.IsUnknown() && !legacyPassword.IsNull() && !woPassword.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Only one of `password` and `password_wo` can be set.",
 		)
 	}
-	if legacyPassword.IsNull() && woPassword.IsNull() {
+	if !legacyPassword.IsUnknown() && !woPassword.IsUnknown() && legacyPassword.IsNull() && woPassword.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Exactly one of `password` and `password_wo` must be set.",
 		)
 	}
-	if !woPassword.IsNull() && woVersionPassword.IsNull() {
+	if !woPassword.IsUnknown() && !woVersionPassword.IsUnknown() && !woPassword.IsNull() && woVersionPassword.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"`password_wo_version` must be set when `password_wo` is used. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.",
 		)
 	}
-	if !legacyPassword.IsNull() {
+	if !legacyPassword.IsUnknown() && !legacyPassword.IsNull() {
 		resp.Diagnostics.AddWarning("Attribute Deprecated", "The `password` attribute stores the secret in Terraform state. Use `password_wo` together with `password_wo_version` instead, which keeps it out of state.")
 	}
 	var legacyEnablePassword types.String
@@ -170,19 +170,19 @@ func (r *CredentialsCLIResource) ValidateConfig(ctx context.Context, req resourc
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("enable_password_wo"), &woEnablePassword)...)
 	var woVersionEnablePassword types.Int64
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("enable_password_wo_version"), &woVersionEnablePassword)...)
-	if !legacyEnablePassword.IsNull() && !woEnablePassword.IsNull() {
+	if !legacyEnablePassword.IsUnknown() && !woEnablePassword.IsUnknown() && !legacyEnablePassword.IsNull() && !woEnablePassword.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Only one of `enable_password` and `enable_password_wo` can be set.",
 		)
 	}
-	if !woEnablePassword.IsNull() && woVersionEnablePassword.IsNull() {
+	if !woEnablePassword.IsUnknown() && !woVersionEnablePassword.IsUnknown() && !woEnablePassword.IsNull() && woVersionEnablePassword.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"`enable_password_wo_version` must be set when `enable_password_wo` is used. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.",
 		)
 	}
-	if !legacyEnablePassword.IsNull() {
+	if !legacyEnablePassword.IsUnknown() && !legacyEnablePassword.IsNull() {
 		resp.Diagnostics.AddWarning("Attribute Deprecated", "The `enable_password` attribute stores the secret in Terraform state. Use `enable_password_wo` together with `enable_password_wo_version` instead, which keeps it out of state.")
 	}
 }

--- a/internal/provider/resource_catalystcenter_credentials_https_read.go
+++ b/internal/provider/resource_catalystcenter_credentials_https_read.go
@@ -135,25 +135,25 @@ func (r *CredentialsHTTPSReadResource) ValidateConfig(ctx context.Context, req r
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("password_wo"), &woPassword)...)
 	var woVersionPassword types.Int64
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("password_wo_version"), &woVersionPassword)...)
-	if !legacyPassword.IsNull() && !woPassword.IsNull() {
+	if !legacyPassword.IsUnknown() && !woPassword.IsUnknown() && !legacyPassword.IsNull() && !woPassword.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Only one of `password` and `password_wo` can be set.",
 		)
 	}
-	if legacyPassword.IsNull() && woPassword.IsNull() {
+	if !legacyPassword.IsUnknown() && !woPassword.IsUnknown() && legacyPassword.IsNull() && woPassword.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Exactly one of `password` and `password_wo` must be set.",
 		)
 	}
-	if !woPassword.IsNull() && woVersionPassword.IsNull() {
+	if !woPassword.IsUnknown() && !woVersionPassword.IsUnknown() && !woPassword.IsNull() && woVersionPassword.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"`password_wo_version` must be set when `password_wo` is used. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.",
 		)
 	}
-	if !legacyPassword.IsNull() {
+	if !legacyPassword.IsUnknown() && !legacyPassword.IsNull() {
 		resp.Diagnostics.AddWarning("Attribute Deprecated", "The `password` attribute stores the secret in Terraform state. Use `password_wo` together with `password_wo_version` instead, which keeps it out of state.")
 	}
 }

--- a/internal/provider/resource_catalystcenter_credentials_https_write.go
+++ b/internal/provider/resource_catalystcenter_credentials_https_write.go
@@ -135,25 +135,25 @@ func (r *CredentialsHTTPSWriteResource) ValidateConfig(ctx context.Context, req 
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("password_wo"), &woPassword)...)
 	var woVersionPassword types.Int64
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("password_wo_version"), &woVersionPassword)...)
-	if !legacyPassword.IsNull() && !woPassword.IsNull() {
+	if !legacyPassword.IsUnknown() && !woPassword.IsUnknown() && !legacyPassword.IsNull() && !woPassword.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Only one of `password` and `password_wo` can be set.",
 		)
 	}
-	if legacyPassword.IsNull() && woPassword.IsNull() {
+	if !legacyPassword.IsUnknown() && !woPassword.IsUnknown() && legacyPassword.IsNull() && woPassword.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Exactly one of `password` and `password_wo` must be set.",
 		)
 	}
-	if !woPassword.IsNull() && woVersionPassword.IsNull() {
+	if !woPassword.IsUnknown() && !woVersionPassword.IsUnknown() && !woPassword.IsNull() && woVersionPassword.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"`password_wo_version` must be set when `password_wo` is used. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.",
 		)
 	}
-	if !legacyPassword.IsNull() {
+	if !legacyPassword.IsUnknown() && !legacyPassword.IsNull() {
 		resp.Diagnostics.AddWarning("Attribute Deprecated", "The `password` attribute stores the secret in Terraform state. Use `password_wo` together with `password_wo_version` instead, which keeps it out of state.")
 	}
 }

--- a/internal/provider/resource_catalystcenter_credentials_snmpv2_read.go
+++ b/internal/provider/resource_catalystcenter_credentials_snmpv2_read.go
@@ -124,25 +124,25 @@ func (r *CredentialsSNMPv2ReadResource) ValidateConfig(ctx context.Context, req 
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("read_community_wo"), &woReadCommunity)...)
 	var woVersionReadCommunity types.Int64
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("read_community_wo_version"), &woVersionReadCommunity)...)
-	if !legacyReadCommunity.IsNull() && !woReadCommunity.IsNull() {
+	if !legacyReadCommunity.IsUnknown() && !woReadCommunity.IsUnknown() && !legacyReadCommunity.IsNull() && !woReadCommunity.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Only one of `read_community` and `read_community_wo` can be set.",
 		)
 	}
-	if legacyReadCommunity.IsNull() && woReadCommunity.IsNull() {
+	if !legacyReadCommunity.IsUnknown() && !woReadCommunity.IsUnknown() && legacyReadCommunity.IsNull() && woReadCommunity.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Exactly one of `read_community` and `read_community_wo` must be set.",
 		)
 	}
-	if !woReadCommunity.IsNull() && woVersionReadCommunity.IsNull() {
+	if !woReadCommunity.IsUnknown() && !woVersionReadCommunity.IsUnknown() && !woReadCommunity.IsNull() && woVersionReadCommunity.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"`read_community_wo_version` must be set when `read_community_wo` is used. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.",
 		)
 	}
-	if !legacyReadCommunity.IsNull() {
+	if !legacyReadCommunity.IsUnknown() && !legacyReadCommunity.IsNull() {
 		resp.Diagnostics.AddWarning("Attribute Deprecated", "The `read_community` attribute stores the secret in Terraform state. Use `read_community_wo` together with `read_community_wo_version` instead, which keeps it out of state.")
 	}
 }

--- a/internal/provider/resource_catalystcenter_credentials_snmpv2_write.go
+++ b/internal/provider/resource_catalystcenter_credentials_snmpv2_write.go
@@ -124,25 +124,25 @@ func (r *CredentialsSNMPv2WriteResource) ValidateConfig(ctx context.Context, req
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("write_community_wo"), &woWriteCommunity)...)
 	var woVersionWriteCommunity types.Int64
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("write_community_wo_version"), &woVersionWriteCommunity)...)
-	if !legacyWriteCommunity.IsNull() && !woWriteCommunity.IsNull() {
+	if !legacyWriteCommunity.IsUnknown() && !woWriteCommunity.IsUnknown() && !legacyWriteCommunity.IsNull() && !woWriteCommunity.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Only one of `write_community` and `write_community_wo` can be set.",
 		)
 	}
-	if legacyWriteCommunity.IsNull() && woWriteCommunity.IsNull() {
+	if !legacyWriteCommunity.IsUnknown() && !woWriteCommunity.IsUnknown() && legacyWriteCommunity.IsNull() && woWriteCommunity.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Exactly one of `write_community` and `write_community_wo` must be set.",
 		)
 	}
-	if !woWriteCommunity.IsNull() && woVersionWriteCommunity.IsNull() {
+	if !woWriteCommunity.IsUnknown() && !woVersionWriteCommunity.IsUnknown() && !woWriteCommunity.IsNull() && woVersionWriteCommunity.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"`write_community_wo_version` must be set when `write_community_wo` is used. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.",
 		)
 	}
-	if !legacyWriteCommunity.IsNull() {
+	if !legacyWriteCommunity.IsUnknown() && !legacyWriteCommunity.IsNull() {
 		resp.Diagnostics.AddWarning("Attribute Deprecated", "The `write_community` attribute stores the secret in Terraform state. Use `write_community_wo` together with `write_community_wo_version` instead, which keeps it out of state.")
 	}
 }

--- a/internal/provider/resource_catalystcenter_credentials_snmpv3.go
+++ b/internal/provider/resource_catalystcenter_credentials_snmpv3.go
@@ -166,19 +166,19 @@ func (r *CredentialsSNMPv3Resource) ValidateConfig(ctx context.Context, req reso
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("privacy_password_wo"), &woPrivacyPassword)...)
 	var woVersionPrivacyPassword types.Int64
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("privacy_password_wo_version"), &woVersionPrivacyPassword)...)
-	if !legacyPrivacyPassword.IsNull() && !woPrivacyPassword.IsNull() {
+	if !legacyPrivacyPassword.IsUnknown() && !woPrivacyPassword.IsUnknown() && !legacyPrivacyPassword.IsNull() && !woPrivacyPassword.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Only one of `privacy_password` and `privacy_password_wo` can be set.",
 		)
 	}
-	if !woPrivacyPassword.IsNull() && woVersionPrivacyPassword.IsNull() {
+	if !woPrivacyPassword.IsUnknown() && !woVersionPrivacyPassword.IsUnknown() && !woPrivacyPassword.IsNull() && woVersionPrivacyPassword.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"`privacy_password_wo_version` must be set when `privacy_password_wo` is used. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.",
 		)
 	}
-	if !legacyPrivacyPassword.IsNull() {
+	if !legacyPrivacyPassword.IsUnknown() && !legacyPrivacyPassword.IsNull() {
 		resp.Diagnostics.AddWarning("Attribute Deprecated", "The `privacy_password` attribute stores the secret in Terraform state. Use `privacy_password_wo` together with `privacy_password_wo_version` instead, which keeps it out of state.")
 	}
 	var legacyAuthPassword types.String
@@ -187,19 +187,19 @@ func (r *CredentialsSNMPv3Resource) ValidateConfig(ctx context.Context, req reso
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("auth_password_wo"), &woAuthPassword)...)
 	var woVersionAuthPassword types.Int64
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("auth_password_wo_version"), &woVersionAuthPassword)...)
-	if !legacyAuthPassword.IsNull() && !woAuthPassword.IsNull() {
+	if !legacyAuthPassword.IsUnknown() && !woAuthPassword.IsUnknown() && !legacyAuthPassword.IsNull() && !woAuthPassword.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Only one of `auth_password` and `auth_password_wo` can be set.",
 		)
 	}
-	if !woAuthPassword.IsNull() && woVersionAuthPassword.IsNull() {
+	if !woAuthPassword.IsUnknown() && !woVersionAuthPassword.IsUnknown() && !woAuthPassword.IsNull() && woVersionAuthPassword.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"`auth_password_wo_version` must be set when `auth_password_wo` is used. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.",
 		)
 	}
-	if !legacyAuthPassword.IsNull() {
+	if !legacyAuthPassword.IsUnknown() && !legacyAuthPassword.IsNull() {
 		resp.Diagnostics.AddWarning("Attribute Deprecated", "The `auth_password` attribute stores the secret in Terraform state. Use `auth_password_wo` together with `auth_password_wo_version` instead, which keeps it out of state.")
 	}
 }

--- a/internal/provider/resource_catalystcenter_lan_automation.go
+++ b/internal/provider/resource_catalystcenter_lan_automation.go
@@ -213,19 +213,19 @@ func (r *LANAutomationResource) ValidateConfig(ctx context.Context, req resource
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("isis_domain_password_wo"), &woIsisDomainPassword)...)
 	var woVersionIsisDomainPassword types.Int64
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("isis_domain_password_wo_version"), &woVersionIsisDomainPassword)...)
-	if !legacyIsisDomainPassword.IsNull() && !woIsisDomainPassword.IsNull() {
+	if !legacyIsisDomainPassword.IsUnknown() && !woIsisDomainPassword.IsUnknown() && !legacyIsisDomainPassword.IsNull() && !woIsisDomainPassword.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Only one of `isis_domain_password` and `isis_domain_password_wo` can be set.",
 		)
 	}
-	if !woIsisDomainPassword.IsNull() && woVersionIsisDomainPassword.IsNull() {
+	if !woIsisDomainPassword.IsUnknown() && !woVersionIsisDomainPassword.IsUnknown() && !woIsisDomainPassword.IsNull() && woVersionIsisDomainPassword.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"`isis_domain_password_wo_version` must be set when `isis_domain_password_wo` is used. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.",
 		)
 	}
-	if !legacyIsisDomainPassword.IsNull() {
+	if !legacyIsisDomainPassword.IsUnknown() && !legacyIsisDomainPassword.IsNull() {
 		resp.Diagnostics.AddWarning("Attribute Deprecated", "The `isis_domain_password` attribute stores the secret in Terraform state. Use `isis_domain_password_wo` together with `isis_domain_password_wo_version` instead, which keeps it out of state.")
 	}
 }

--- a/internal/provider/resource_catalystcenter_user.go
+++ b/internal/provider/resource_catalystcenter_user.go
@@ -138,25 +138,25 @@ func (r *UserResource) ValidateConfig(ctx context.Context, req resource.Validate
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("password_wo"), &woPassword)...)
 	var woVersionPassword types.Int64
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("password_wo_version"), &woVersionPassword)...)
-	if !legacyPassword.IsNull() && !woPassword.IsNull() {
+	if !legacyPassword.IsUnknown() && !woPassword.IsUnknown() && !legacyPassword.IsNull() && !woPassword.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Only one of `password` and `password_wo` can be set.",
 		)
 	}
-	if legacyPassword.IsNull() && woPassword.IsNull() {
+	if !legacyPassword.IsUnknown() && !woPassword.IsUnknown() && legacyPassword.IsNull() && woPassword.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Exactly one of `password` and `password_wo` must be set.",
 		)
 	}
-	if !woPassword.IsNull() && woVersionPassword.IsNull() {
+	if !woPassword.IsUnknown() && !woVersionPassword.IsUnknown() && !woPassword.IsNull() && woVersionPassword.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"`password_wo_version` must be set when `password_wo` is used. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.",
 		)
 	}
-	if !legacyPassword.IsNull() {
+	if !legacyPassword.IsUnknown() && !legacyPassword.IsNull() {
 		resp.Diagnostics.AddWarning("Attribute Deprecated", "The `password` attribute stores the secret in Terraform state. Use `password_wo` together with `password_wo_version` instead, which keeps it out of state.")
 	}
 }

--- a/internal/provider/resource_catalystcenter_wireless_ssid.go
+++ b/internal/provider/resource_catalystcenter_wireless_ssid.go
@@ -488,19 +488,19 @@ func (r *WirelessSSIDResource) ValidateConfig(ctx context.Context, req resource.
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("passphrase_wo"), &woPassphrase)...)
 	var woVersionPassphrase types.Int64
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("passphrase_wo_version"), &woVersionPassphrase)...)
-	if !legacyPassphrase.IsNull() && !woPassphrase.IsNull() {
+	if !legacyPassphrase.IsUnknown() && !woPassphrase.IsUnknown() && !legacyPassphrase.IsNull() && !woPassphrase.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"Only one of `passphrase` and `passphrase_wo` can be set.",
 		)
 	}
-	if !woPassphrase.IsNull() && woVersionPassphrase.IsNull() {
+	if !woPassphrase.IsUnknown() && !woVersionPassphrase.IsUnknown() && !woPassphrase.IsNull() && woVersionPassphrase.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Attribute Combination",
 			"`passphrase_wo_version` must be set when `passphrase_wo` is used. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.",
 		)
 	}
-	if !legacyPassphrase.IsNull() {
+	if !legacyPassphrase.IsUnknown() && !legacyPassphrase.IsNull() {
 		resp.Diagnostics.AddWarning("Attribute Deprecated", "The `passphrase` attribute stores the secret in Terraform state. Use `passphrase_wo` together with `passphrase_wo_version` instead, which keeps it out of state.")
 	}
 	{
@@ -510,19 +510,19 @@ func (r *WirelessSSIDResource) ValidateConfig(ctx context.Context, req resource.
 		var cfgMultiPskSettings []WirelessSSIDMultiPskSettings
 		if diags := req.Config.GetAttribute(ctx, path.Root("multi_psk_settings"), &cfgMultiPskSettings); !diags.HasError() {
 			for i := range cfgMultiPskSettings {
-				if !cfgMultiPskSettings[i].Passphrase.IsNull() && !cfgMultiPskSettings[i].PassphraseWo.IsNull() {
+				if !cfgMultiPskSettings[i].Passphrase.IsUnknown() && !cfgMultiPskSettings[i].PassphraseWo.IsUnknown() && !cfgMultiPskSettings[i].Passphrase.IsNull() && !cfgMultiPskSettings[i].PassphraseWo.IsNull() {
 					resp.Diagnostics.AddError(
 						"Invalid Attribute Combination",
 						fmt.Sprintf("Only one of `passphrase` and `passphrase_wo` can be set in `multi_psk_settings` element %d.", i),
 					)
 				}
-				if !cfgMultiPskSettings[i].PassphraseWo.IsNull() && cfgMultiPskSettings[i].PassphraseWoVersion.IsNull() {
+				if !cfgMultiPskSettings[i].PassphraseWo.IsUnknown() && !cfgMultiPskSettings[i].PassphraseWoVersion.IsUnknown() && !cfgMultiPskSettings[i].PassphraseWo.IsNull() && cfgMultiPskSettings[i].PassphraseWoVersion.IsNull() {
 					resp.Diagnostics.AddError(
 						"Invalid Attribute Combination",
 						fmt.Sprintf("`passphrase_wo_version` must be set when `passphrase_wo` is used in `multi_psk_settings` element %d. The write-only value is not stored in state, so Terraform can only detect a change to it through the version.", i),
 					)
 				}
-				if !cfgMultiPskSettings[i].Passphrase.IsNull() {
+				if !cfgMultiPskSettings[i].Passphrase.IsUnknown() && !cfgMultiPskSettings[i].Passphrase.IsNull() {
 					resp.Diagnostics.AddWarning("Attribute Deprecated", fmt.Sprintf("The `passphrase` attribute stores the secret in Terraform state. Use `passphrase_wo` together with `passphrase_wo_version` instead, which keeps it out of state. (`multi_psk_settings` element %d)", i))
 				}
 			}


### PR DESCRIPTION
The ValidateConfig checks added for write-only secrets tested IsNull() only. An unknown value is not null, so a secret whose value is not yet known at validation time - anything sourced from a variable, a module output or another resource - counted as "set", and every pair of checks fired against it.

In practice this made the pairs unusable from a module. The NAC module feeds every credential from a module output, so `terraform validate` failed on each converted resource with, for example:

  Error: Invalid Attribute Combination
    with catalystcenter_wireless_ssid.ssid,
  Only one of `passphrase` and `passphrase_wo` can be set.

even though exactly one of the two was being set.

Defer on unknown, as the schema validators these checks replaced already did (ConflictsWith, ExactlyOneOf and AlsoRequires all return early on req.ConfigValue.IsUnknown()). The mutual-exclusion and version checks are skipped while either value is unknown, and the deprecation warning is raised only for a legacy attribute that is known and non-null, so it is not emitted spuriously when both halves are still unknown.

Applies to the top-level and the per-list-element checks alike.