### PR TITLE
add support for additional pools

### DIFF
--- a/docs/data-sources/anycast_gateway.md
+++ b/docs/data-sources/anycast_gateway.md
@@ -31,6 +31,7 @@ data "catalystcenter_anycast_gateway" "example" {
 
 ### Read-Only
 
+- `additional_ip_pools` (Attributes List) Names of up to 4 additional (secondary) IP pools associated with the anycast gateway. Additional IP pools provide more IP addresses that can be used when the primary IP pool is exhausted. When an additional IP pool is exhausted, the next IP pool is used. The order in which the additional IP pools are used is defined by the order property. IP pools with lower order numbers will be used first (not applicable to INFRA_VN) (see [below for nested schema](#nestedatt--additional_ip_pools))
 - `auto_generate_vlan_name` (Boolean) This field cannot be true when vlanName is provided. the vlanName will be generated as ipPoolGroupV4Cidr-virtualNetworkName for non-critical VLANs. for critical VLANs with DATA trafficType, vlanName will be CRITICAL_VLAN. for critical VLANs with VOICE trafficType, vlanName will be VOICE_VLAN
 - `critical_pool` (Boolean) Enable/disable critical VLAN. if true, autoGenerateVlanName must also be true. (isCriticalPool is not applicable to INFRA_VN)
 - `group_based_policy_enforcement_enabled` (Boolean) Enable/disable Group-Based Policy Enforcement (applicable only to INFRA_VN; defaults to false)
@@ -47,3 +48,11 @@ data "catalystcenter_anycast_gateway" "example" {
 - `vlan_id` (Number) ID of the VLAN of the anycast gateway. allowed VLAN range is 2-4093 except for reserved VLANs 1002-1005, 2046, and 4094. if deploying an anycast gateway on a fabric zone, this vlanId must match the vlanId of the corresponding anycast gateway on the fabric site
 - `vlan_name` (String) Name of the VLAN of the anycast gateway
 - `wireless_pool` (Boolean) Enable/disable fabric-enabled wireless (not applicable to INFRA_VN)
+
+<a id="nestedatt--additional_ip_pools"></a>
+### Nested Schema for `additional_ip_pools`
+
+Read-Only:
+
+- `name` (String) Name of the additional IP pool associated with the anycast gateway
+- `order` (Number) Sequence in which this IP pool will be used

--- a/docs/data-sources/anycast_gateways.md
+++ b/docs/data-sources/anycast_gateways.md
@@ -36,6 +36,7 @@ data "catalystcenter_anycast_gateways" "example" {
 
 Read-Only:
 
+- `additional_ip_pools` (Attributes List) Names of up to 4 additional (secondary) IP pools associated with the anycast gateway. Additional IP pools provide more IP addresses that can be used when the primary IP pool is exhausted. When an additional IP pool is exhausted, the next IP pool is used. The order in which the additional IP pools are used is defined by the order property. IP pools with lower order numbers will be used first (not applicable to INFRA_VN) (see [below for nested schema](#nestedatt--anycast_gateways--additional_ip_pools))
 - `auto_generate_vlan_name` (Boolean) This field cannot be true when vlanName is provided. the vlanName will be generated as ipPoolGroupV4Cidr-virtualNetworkName for non-critical VLANs. for critical VLANs with DATA trafficType, vlanName will be CRITICAL_VLAN. for critical VLANs with VOICE trafficType, vlanName will be VOICE_VLAN
 - `critical_pool` (Boolean) Enable/disable critical VLAN. if true, autoGenerateVlanName must also be true. (isCriticalPool is not applicable to INFRA_VN)
 - `fabric_id` (String) ID of the fabric to contain this anycast gateway
@@ -55,3 +56,11 @@ Read-Only:
 - `vlan_id` (Number) ID of the VLAN of the anycast gateway. allowed VLAN range is 2-4093 except for reserved VLANs 1002-1005, 2046, and 4094. if deploying an anycast gateway on a fabric zone, this vlanId must match the vlanId of the corresponding anycast gateway on the fabric site
 - `vlan_name` (String) Name of the VLAN of the anycast gateway
 - `wireless_pool` (Boolean) Enable/disable fabric-enabled wireless (not applicable to INFRA_VN)
+
+<a id="nestedatt--anycast_gateways--additional_ip_pools"></a>
+### Nested Schema for `anycast_gateways.additional_ip_pools`
+
+Read-Only:
+
+- `name` (String) Name of the additional IP pool associated with the anycast gateway
+- `order` (Number) Sequence in which this IP pool will be used

--- a/docs/resources/anycast_gateway.md
+++ b/docs/resources/anycast_gateway.md
@@ -44,6 +44,7 @@ resource "catalystcenter_anycast_gateway" "example" {
 
 ### Optional
 
+- `additional_ip_pools` (Attributes List) Names of up to 4 additional (secondary) IP pools associated with the anycast gateway. Additional IP pools provide more IP addresses that can be used when the primary IP pool is exhausted. When an additional IP pool is exhausted, the next IP pool is used. The order in which the additional IP pools are used is defined by the order property. IP pools with lower order numbers will be used first (not applicable to INFRA_VN) (see [below for nested schema](#nestedatt--additional_ip_pools))
 - `critical_pool` (Boolean) Enable/disable critical VLAN. if true, autoGenerateVlanName must also be true. (isCriticalPool is not applicable to INFRA_VN)
 - `group_based_policy_enforcement_enabled` (Boolean) Enable/disable Group-Based Policy Enforcement (applicable only to INFRA_VN; defaults to false)
 - `intra_subnet_routing_enabled` (Boolean) Enable/disable Intra-Subnet Routing (not applicable to INFRA_VN)
@@ -63,6 +64,15 @@ resource "catalystcenter_anycast_gateway" "example" {
 ### Read-Only
 
 - `id` (String) The id of the object
+
+<a id="nestedatt--additional_ip_pools"></a>
+### Nested Schema for `additional_ip_pools`
+
+Required:
+
+- `name` (String) Name of the additional IP pool associated with the anycast gateway
+- `order` (Number) Sequence in which this IP pool will be used
+  - Range: `2`-`5`
 
 ## Import
 

--- a/docs/resources/anycast_gateways.md
+++ b/docs/resources/anycast_gateways.md
@@ -61,6 +61,7 @@ Required:
 
 Optional:
 
+- `additional_ip_pools` (Attributes List) Names of up to 4 additional (secondary) IP pools associated with the anycast gateway. Additional IP pools provide more IP addresses that can be used when the primary IP pool is exhausted. When an additional IP pool is exhausted, the next IP pool is used. The order in which the additional IP pools are used is defined by the order property. IP pools with lower order numbers will be used first (not applicable to INFRA_VN) (see [below for nested schema](#nestedatt--anycast_gateways--additional_ip_pools))
 - `critical_pool` (Boolean) Enable/disable critical VLAN. if true, autoGenerateVlanName must also be true. (isCriticalPool is not applicable to INFRA_VN)
 - `group_based_policy_enforcement_enabled` (Boolean) Enable/disable Group-Based Policy Enforcement (applicable only to INFRA_VN; defaults to false)
 - `intra_subnet_routing_enabled` (Boolean) Enable/disable Intra-Subnet Routing (not applicable to INFRA_VN)
@@ -80,6 +81,15 @@ Optional:
 Read-Only:
 
 - `id` (String) ID of the anycast gateway
+
+<a id="nestedatt--anycast_gateways--additional_ip_pools"></a>
+### Nested Schema for `anycast_gateways.additional_ip_pools`
+
+Required:
+
+- `name` (String) Name of the additional IP pool associated with the anycast gateway
+- `order` (Number) Sequence in which this IP pool will be used
+  - Range: `2`-`5`
 
 ## Import
 

--- a/gen/definitions/anycast_gateway.yaml
+++ b/gen/definitions/anycast_gateway.yaml
@@ -44,6 +44,23 @@ attributes:
     description: Name of the IP pool associated with the anycast gateway
     example: MyRes1
     test_value: catalystcenter_ip_pool_reservation.test.name
+  - model_name: additionalIpPools
+    data_path: '0'
+    response_data_path: response.0.additionalIpPools
+    type: List
+    description: Names of up to 4 additional (secondary) IP pools associated with the anycast gateway. Additional IP pools provide more IP addresses that can be used when the primary IP pool is exhausted. When an additional IP pool is exhausted, the next IP pool is used. The order in which the additional IP pools are used is defined by the order property. IP pools with lower order numbers will be used first (not applicable to INFRA_VN)
+    exclude_test: true
+    attributes:
+      - model_name: name
+        type: String
+        mandatory: true
+        description: Name of the additional IP pool associated with the anycast gateway
+      - model_name: order
+        type: Int64
+        mandatory: true
+        min_int: 2
+        max_int: 5
+        description: Sequence in which this IP pool will be used
   - model_name: tcpMssAdjustment
     data_path: '0'
     response_data_path: response.0.tcpMssAdjustment

--- a/gen/definitions/anycast_gateways.yaml
+++ b/gen/definitions/anycast_gateways.yaml
@@ -56,6 +56,21 @@ attributes:
         description: Name of the IP pool associated with the anycast gateway
         example: MyRes1
         test_value: catalystcenter_ip_pool_reservation.test.name
+      - model_name: additionalIpPools
+        type: List
+        description: Names of up to 4 additional (secondary) IP pools associated with the anycast gateway. Additional IP pools provide more IP addresses that can be used when the primary IP pool is exhausted. When an additional IP pool is exhausted, the next IP pool is used. The order in which the additional IP pools are used is defined by the order property. IP pools with lower order numbers will be used first (not applicable to INFRA_VN)
+        exclude_test: true
+        attributes:
+          - model_name: name
+            type: String
+            mandatory: true
+            description: Name of the additional IP pool associated with the anycast gateway
+          - model_name: order
+            type: Int64
+            mandatory: true
+            min_int: 2
+            max_int: 5
+            description: Sequence in which this IP pool will be used
       - model_name: tcpMssAdjustment
         type: Int64
         min_int: 500

--- a/gen/templates/model.go
+++ b/gen/templates/model.go
@@ -1280,6 +1280,7 @@ for i := range data.{{toGoName .TfName}} {
 			return true
 		},
 	)
+	_ = r
 
 	{{- range .Attributes}}
 	{{- if and (not .Value) (not .WriteOnly) (not .Reference) .Computed}}

--- a/internal/provider/data_source_catalystcenter_anycast_gateway.go
+++ b/internal/provider/data_source_catalystcenter_anycast_gateway.go
@@ -73,6 +73,22 @@ func (d *AnycastGatewayDataSource) Schema(ctx context.Context, req datasource.Sc
 				MarkdownDescription: "Name of the IP pool associated with the anycast gateway",
 				Required:            true,
 			},
+			"additional_ip_pools": schema.ListNestedAttribute{
+				MarkdownDescription: "Names of up to 4 additional (secondary) IP pools associated with the anycast gateway. Additional IP pools provide more IP addresses that can be used when the primary IP pool is exhausted. When an additional IP pool is exhausted, the next IP pool is used. The order in which the additional IP pools are used is defined by the order property. IP pools with lower order numbers will be used first (not applicable to INFRA_VN)",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							MarkdownDescription: "Name of the additional IP pool associated with the anycast gateway",
+							Computed:            true,
+						},
+						"order": schema.Int64Attribute{
+							MarkdownDescription: "Sequence in which this IP pool will be used",
+							Computed:            true,
+						},
+					},
+				},
+			},
 			"tcp_mss_adjustment": schema.Int64Attribute{
 				MarkdownDescription: "TCP maximum segment size adjustment",
 				Computed:            true,

--- a/internal/provider/data_source_catalystcenter_anycast_gateways.go
+++ b/internal/provider/data_source_catalystcenter_anycast_gateways.go
@@ -86,6 +86,22 @@ func (d *AnycastGatewaysDataSource) Schema(ctx context.Context, req datasource.S
 							MarkdownDescription: "Name of the IP pool associated with the anycast gateway",
 							Computed:            true,
 						},
+						"additional_ip_pools": schema.ListNestedAttribute{
+							MarkdownDescription: "Names of up to 4 additional (secondary) IP pools associated with the anycast gateway. Additional IP pools provide more IP addresses that can be used when the primary IP pool is exhausted. When an additional IP pool is exhausted, the next IP pool is used. The order in which the additional IP pools are used is defined by the order property. IP pools with lower order numbers will be used first (not applicable to INFRA_VN)",
+							Computed:            true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"name": schema.StringAttribute{
+										MarkdownDescription: "Name of the additional IP pool associated with the anycast gateway",
+										Computed:            true,
+									},
+									"order": schema.Int64Attribute{
+										MarkdownDescription: "Sequence in which this IP pool will be used",
+										Computed:            true,
+									},
+								},
+							},
+						},
 						"tcp_mss_adjustment": schema.Int64Attribute{
 							MarkdownDescription: "TCP maximum segment size adjustment",
 							Computed:            true,

--- a/internal/provider/model_catalystcenter_anycast_gateway.go
+++ b/internal/provider/model_catalystcenter_anycast_gateway.go
@@ -20,6 +20,7 @@ package provider
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
 	"context"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/tidwall/gjson"
@@ -30,25 +31,31 @@ import (
 
 // Section below is generated&owned by "gen/generator.go". //template:begin types
 type AnycastGateway struct {
-	Id                                    types.String `tfsdk:"id"`
-	FabricId                              types.String `tfsdk:"fabric_id"`
-	VirtualNetworkName                    types.String `tfsdk:"virtual_network_name"`
-	IpPoolName                            types.String `tfsdk:"ip_pool_name"`
-	TcpMssAdjustment                      types.Int64  `tfsdk:"tcp_mss_adjustment"`
-	VlanName                              types.String `tfsdk:"vlan_name"`
-	VlanId                                types.Int64  `tfsdk:"vlan_id"`
-	TrafficType                           types.String `tfsdk:"traffic_type"`
-	PoolType                              types.String `tfsdk:"pool_type"`
-	SecurityGroupName                     types.String `tfsdk:"security_group_name"`
-	CriticalPool                          types.Bool   `tfsdk:"critical_pool"`
-	L2FloodingEnabled                     types.Bool   `tfsdk:"l2_flooding_enabled"`
-	WirelessPool                          types.Bool   `tfsdk:"wireless_pool"`
-	IpDirectedBroadcast                   types.Bool   `tfsdk:"ip_directed_broadcast"`
-	IntraSubnetRoutingEnabled             types.Bool   `tfsdk:"intra_subnet_routing_enabled"`
-	MultipleIpToMacAddresses              types.Bool   `tfsdk:"multiple_ip_to_mac_addresses"`
-	SupplicantBasedExtendedNodeOnboarding types.Bool   `tfsdk:"supplicant_based_extended_node_onboarding"`
-	GroupBasedPolicyEnforcementEnabled    types.Bool   `tfsdk:"group_based_policy_enforcement_enabled"`
-	AutoGenerateVlanName                  types.Bool   `tfsdk:"auto_generate_vlan_name"`
+	Id                                    types.String                      `tfsdk:"id"`
+	FabricId                              types.String                      `tfsdk:"fabric_id"`
+	VirtualNetworkName                    types.String                      `tfsdk:"virtual_network_name"`
+	IpPoolName                            types.String                      `tfsdk:"ip_pool_name"`
+	AdditionalIpPools                     []AnycastGatewayAdditionalIpPools `tfsdk:"additional_ip_pools"`
+	TcpMssAdjustment                      types.Int64                       `tfsdk:"tcp_mss_adjustment"`
+	VlanName                              types.String                      `tfsdk:"vlan_name"`
+	VlanId                                types.Int64                       `tfsdk:"vlan_id"`
+	TrafficType                           types.String                      `tfsdk:"traffic_type"`
+	PoolType                              types.String                      `tfsdk:"pool_type"`
+	SecurityGroupName                     types.String                      `tfsdk:"security_group_name"`
+	CriticalPool                          types.Bool                        `tfsdk:"critical_pool"`
+	L2FloodingEnabled                     types.Bool                        `tfsdk:"l2_flooding_enabled"`
+	WirelessPool                          types.Bool                        `tfsdk:"wireless_pool"`
+	IpDirectedBroadcast                   types.Bool                        `tfsdk:"ip_directed_broadcast"`
+	IntraSubnetRoutingEnabled             types.Bool                        `tfsdk:"intra_subnet_routing_enabled"`
+	MultipleIpToMacAddresses              types.Bool                        `tfsdk:"multiple_ip_to_mac_addresses"`
+	SupplicantBasedExtendedNodeOnboarding types.Bool                        `tfsdk:"supplicant_based_extended_node_onboarding"`
+	GroupBasedPolicyEnforcementEnabled    types.Bool                        `tfsdk:"group_based_policy_enforcement_enabled"`
+	AutoGenerateVlanName                  types.Bool                        `tfsdk:"auto_generate_vlan_name"`
+}
+
+type AnycastGatewayAdditionalIpPools struct {
+	Name  types.String `tfsdk:"name"`
+	Order types.Int64  `tfsdk:"order"`
 }
 
 // End of section. //template:end types
@@ -81,6 +88,19 @@ func (data AnycastGateway) toBody(ctx context.Context, state AnycastGateway) str
 	}
 	if !data.IpPoolName.IsNull() {
 		body, _ = sjson.Set(body, "0.ipPoolName", data.IpPoolName.ValueString())
+	}
+	if len(data.AdditionalIpPools) > 0 {
+		body, _ = sjson.Set(body, "0.additionalIpPools", []interface{}{})
+		for _, item := range data.AdditionalIpPools {
+			itemBody := ""
+			if !item.Name.IsNull() {
+				itemBody, _ = sjson.Set(itemBody, "name", item.Name.ValueString())
+			}
+			if !item.Order.IsNull() {
+				itemBody, _ = sjson.Set(itemBody, "order", item.Order.ValueInt64())
+			}
+			body, _ = sjson.SetRaw(body, "0.additionalIpPools.-1", itemBody)
+		}
 	}
 	if !data.TcpMssAdjustment.IsNull() {
 		body, _ = sjson.Set(body, "0.tcpMssAdjustment", data.TcpMssAdjustment.ValueInt64())
@@ -154,6 +174,24 @@ func (data *AnycastGateway) fromBody(ctx context.Context, res gjson.Result) {
 		data.IpPoolName = types.StringValue(value.String())
 	} else {
 		data.IpPoolName = types.StringNull()
+	}
+	if value := res.Get("response.0.additionalIpPools"); value.Exists() && len(value.Array()) > 0 {
+		data.AdditionalIpPools = make([]AnycastGatewayAdditionalIpPools, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := AnycastGatewayAdditionalIpPools{}
+			if cValue := v.Get("name"); cValue.Exists() {
+				item.Name = types.StringValue(cValue.String())
+			} else {
+				item.Name = types.StringNull()
+			}
+			if cValue := v.Get("order"); cValue.Exists() {
+				item.Order = types.Int64Value(cValue.Int())
+			} else {
+				item.Order = types.Int64Null()
+			}
+			data.AdditionalIpPools = append(data.AdditionalIpPools, item)
+			return true
+		})
 	}
 	if value := res.Get("response.0.tcpMssAdjustment"); value.Exists() {
 		data.TcpMssAdjustment = types.Int64Value(value.Int())
@@ -245,6 +283,40 @@ func (data *AnycastGateway) updateFromBody(ctx context.Context, res gjson.Result
 		data.IpPoolName = types.StringValue(value.String())
 	} else {
 		data.IpPoolName = types.StringNull()
+	}
+	for i := range data.AdditionalIpPools {
+		keys := [...]string{"name", "order"}
+		keyValues := [...]string{data.AdditionalIpPools[i].Name.ValueString(), strconv.FormatInt(data.AdditionalIpPools[i].Order.ValueInt64(), 10)}
+
+		var r gjson.Result
+		res.Get("response.0.additionalIpPools").ForEach(
+			func(_, v gjson.Result) bool {
+				found := false
+				for ik := range keys {
+					if v.Get(keys[ik]).String() == keyValues[ik] {
+						found = true
+						continue
+					}
+					found = false
+					break
+				}
+				if found {
+					r = v
+					return false
+				}
+				return true
+			},
+		)
+		if value := r.Get("name"); value.Exists() && !data.AdditionalIpPools[i].Name.IsNull() {
+			data.AdditionalIpPools[i].Name = types.StringValue(value.String())
+		} else {
+			data.AdditionalIpPools[i].Name = types.StringNull()
+		}
+		if value := r.Get("order"); value.Exists() && !data.AdditionalIpPools[i].Order.IsNull() {
+			data.AdditionalIpPools[i].Order = types.Int64Value(value.Int())
+		} else {
+			data.AdditionalIpPools[i].Order = types.Int64Null()
+		}
 	}
 	if value := res.Get("response.0.tcpMssAdjustment"); value.Exists() && !data.TcpMssAdjustment.IsNull() {
 		data.TcpMssAdjustment = types.Int64Value(value.Int())
@@ -345,6 +417,31 @@ func (data *AnycastGateway) fromBodyUnknowns(ctx context.Context, res gjson.Resu
 		} else {
 			data.IpPoolName = types.StringNull()
 		}
+	}
+	for i := range data.AdditionalIpPools {
+		keys := [...]string{"name", "order"}
+		keyValues := [...]string{data.AdditionalIpPools[i].Name.ValueString(), strconv.FormatInt(data.AdditionalIpPools[i].Order.ValueInt64(), 10)}
+
+		var r gjson.Result
+		res.Get("response.0.additionalIpPools").ForEach(
+			func(_, v gjson.Result) bool {
+				found := false
+				for ik := range keys {
+					if v.Get(keys[ik]).String() == keyValues[ik] {
+						found = true
+						continue
+					}
+					found = false
+					break
+				}
+				if found {
+					r = v
+					return false
+				}
+				return true
+			},
+		)
+		_ = r
 	}
 	if data.TcpMssAdjustment.IsUnknown() {
 		if value := res.Get("response.0.tcpMssAdjustment"); value.Exists() && !data.TcpMssAdjustment.IsNull() {
@@ -450,6 +547,9 @@ func (data *AnycastGateway) fromBodyUnknowns(ctx context.Context, res gjson.Resu
 
 // Section below is generated&owned by "gen/generator.go". //template:begin isNull
 func (data *AnycastGateway) isNull(ctx context.Context, res gjson.Result) bool {
+	if len(data.AdditionalIpPools) > 0 {
+		return false
+	}
 	if !data.TcpMssAdjustment.IsNull() {
 		return false
 	}

--- a/internal/provider/model_catalystcenter_anycast_gateways.go
+++ b/internal/provider/model_catalystcenter_anycast_gateways.go
@@ -20,6 +20,7 @@ package provider
 // Section below is generated&owned by "gen/generator.go". //template:begin imports
 import (
 	"context"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/tidwall/gjson"
@@ -36,25 +37,31 @@ type AnycastGateways struct {
 }
 
 type AnycastGatewaysAnycastGateways struct {
-	Id                                    types.String `tfsdk:"id"`
-	FabricId                              types.String `tfsdk:"fabric_id"`
-	VirtualNetworkName                    types.String `tfsdk:"virtual_network_name"`
-	IpPoolName                            types.String `tfsdk:"ip_pool_name"`
-	TcpMssAdjustment                      types.Int64  `tfsdk:"tcp_mss_adjustment"`
-	VlanName                              types.String `tfsdk:"vlan_name"`
-	VlanId                                types.Int64  `tfsdk:"vlan_id"`
-	TrafficType                           types.String `tfsdk:"traffic_type"`
-	PoolType                              types.String `tfsdk:"pool_type"`
-	SecurityGroupName                     types.String `tfsdk:"security_group_name"`
-	CriticalPool                          types.Bool   `tfsdk:"critical_pool"`
-	L2FloodingEnabled                     types.Bool   `tfsdk:"l2_flooding_enabled"`
-	WirelessPool                          types.Bool   `tfsdk:"wireless_pool"`
-	IpDirectedBroadcast                   types.Bool   `tfsdk:"ip_directed_broadcast"`
-	IntraSubnetRoutingEnabled             types.Bool   `tfsdk:"intra_subnet_routing_enabled"`
-	MultipleIpToMacAddresses              types.Bool   `tfsdk:"multiple_ip_to_mac_addresses"`
-	SupplicantBasedExtendedNodeOnboarding types.Bool   `tfsdk:"supplicant_based_extended_node_onboarding"`
-	GroupBasedPolicyEnforcementEnabled    types.Bool   `tfsdk:"group_based_policy_enforcement_enabled"`
-	AutoGenerateVlanName                  types.Bool   `tfsdk:"auto_generate_vlan_name"`
+	Id                                    types.String                                      `tfsdk:"id"`
+	FabricId                              types.String                                      `tfsdk:"fabric_id"`
+	VirtualNetworkName                    types.String                                      `tfsdk:"virtual_network_name"`
+	IpPoolName                            types.String                                      `tfsdk:"ip_pool_name"`
+	AdditionalIpPools                     []AnycastGatewaysAnycastGatewaysAdditionalIpPools `tfsdk:"additional_ip_pools"`
+	TcpMssAdjustment                      types.Int64                                       `tfsdk:"tcp_mss_adjustment"`
+	VlanName                              types.String                                      `tfsdk:"vlan_name"`
+	VlanId                                types.Int64                                       `tfsdk:"vlan_id"`
+	TrafficType                           types.String                                      `tfsdk:"traffic_type"`
+	PoolType                              types.String                                      `tfsdk:"pool_type"`
+	SecurityGroupName                     types.String                                      `tfsdk:"security_group_name"`
+	CriticalPool                          types.Bool                                        `tfsdk:"critical_pool"`
+	L2FloodingEnabled                     types.Bool                                        `tfsdk:"l2_flooding_enabled"`
+	WirelessPool                          types.Bool                                        `tfsdk:"wireless_pool"`
+	IpDirectedBroadcast                   types.Bool                                        `tfsdk:"ip_directed_broadcast"`
+	IntraSubnetRoutingEnabled             types.Bool                                        `tfsdk:"intra_subnet_routing_enabled"`
+	MultipleIpToMacAddresses              types.Bool                                        `tfsdk:"multiple_ip_to_mac_addresses"`
+	SupplicantBasedExtendedNodeOnboarding types.Bool                                        `tfsdk:"supplicant_based_extended_node_onboarding"`
+	GroupBasedPolicyEnforcementEnabled    types.Bool                                        `tfsdk:"group_based_policy_enforcement_enabled"`
+	AutoGenerateVlanName                  types.Bool                                        `tfsdk:"auto_generate_vlan_name"`
+}
+
+type AnycastGatewaysAnycastGatewaysAdditionalIpPools struct {
+	Name  types.String `tfsdk:"name"`
+	Order types.Int64  `tfsdk:"order"`
 }
 
 // End of section. //template:end types
@@ -96,6 +103,19 @@ func (data AnycastGateways) toBody(ctx context.Context, state AnycastGateways) s
 			}
 			if !item.IpPoolName.IsNull() {
 				itemBody, _ = sjson.Set(itemBody, "ipPoolName", item.IpPoolName.ValueString())
+			}
+			if len(item.AdditionalIpPools) > 0 {
+				itemBody, _ = sjson.Set(itemBody, "additionalIpPools", []interface{}{})
+				for _, childItem := range item.AdditionalIpPools {
+					itemChildBody := ""
+					if !childItem.Name.IsNull() {
+						itemChildBody, _ = sjson.Set(itemChildBody, "name", childItem.Name.ValueString())
+					}
+					if !childItem.Order.IsNull() {
+						itemChildBody, _ = sjson.Set(itemChildBody, "order", childItem.Order.ValueInt64())
+					}
+					itemBody, _ = sjson.SetRaw(itemBody, "additionalIpPools.-1", itemChildBody)
+				}
 			}
 			if !item.TcpMssAdjustment.IsNull() {
 				itemBody, _ = sjson.Set(itemBody, "tcpMssAdjustment", item.TcpMssAdjustment.ValueInt64())
@@ -177,6 +197,24 @@ func (data *AnycastGateways) fromBody(ctx context.Context, res gjson.Result) {
 				item.IpPoolName = types.StringValue(cValue.String())
 			} else {
 				item.IpPoolName = types.StringNull()
+			}
+			if cValue := v.Get("additionalIpPools"); cValue.Exists() && len(cValue.Array()) > 0 {
+				item.AdditionalIpPools = make([]AnycastGatewaysAnycastGatewaysAdditionalIpPools, 0)
+				cValue.ForEach(func(ck, cv gjson.Result) bool {
+					cItem := AnycastGatewaysAnycastGatewaysAdditionalIpPools{}
+					if ccValue := cv.Get("name"); ccValue.Exists() {
+						cItem.Name = types.StringValue(ccValue.String())
+					} else {
+						cItem.Name = types.StringNull()
+					}
+					if ccValue := cv.Get("order"); ccValue.Exists() {
+						cItem.Order = types.Int64Value(ccValue.Int())
+					} else {
+						cItem.Order = types.Int64Null()
+					}
+					item.AdditionalIpPools = append(item.AdditionalIpPools, cItem)
+					return true
+				})
 			}
 			if cValue := v.Get("tcpMssAdjustment"); cValue.Exists() {
 				item.TcpMssAdjustment = types.Int64Value(cValue.Int())
@@ -305,6 +343,40 @@ func (data *AnycastGateways) updateFromBody(ctx context.Context, res gjson.Resul
 		} else {
 			data.AnycastGateways[i].IpPoolName = types.StringNull()
 		}
+		for ci := range data.AnycastGateways[i].AdditionalIpPools {
+			keys := [...]string{"name", "order"}
+			keyValues := [...]string{data.AnycastGateways[i].AdditionalIpPools[ci].Name.ValueString(), strconv.FormatInt(data.AnycastGateways[i].AdditionalIpPools[ci].Order.ValueInt64(), 10)}
+
+			var cr gjson.Result
+			r.Get("additionalIpPools").ForEach(
+				func(_, v gjson.Result) bool {
+					found := false
+					for ik := range keys {
+						if v.Get(keys[ik]).String() == keyValues[ik] {
+							found = true
+							continue
+						}
+						found = false
+						break
+					}
+					if found {
+						cr = v
+						return false
+					}
+					return true
+				},
+			)
+			if value := cr.Get("name"); value.Exists() && !data.AnycastGateways[i].AdditionalIpPools[ci].Name.IsNull() {
+				data.AnycastGateways[i].AdditionalIpPools[ci].Name = types.StringValue(value.String())
+			} else {
+				data.AnycastGateways[i].AdditionalIpPools[ci].Name = types.StringNull()
+			}
+			if value := cr.Get("order"); value.Exists() && !data.AnycastGateways[i].AdditionalIpPools[ci].Order.IsNull() {
+				data.AnycastGateways[i].AdditionalIpPools[ci].Order = types.Int64Value(value.Int())
+			} else {
+				data.AnycastGateways[i].AdditionalIpPools[ci].Order = types.Int64Null()
+			}
+		}
 		if value := r.Get("tcpMssAdjustment"); value.Exists() && !data.AnycastGateways[i].TcpMssAdjustment.IsNull() {
 			data.AnycastGateways[i].TcpMssAdjustment = types.Int64Value(value.Int())
 		} else {
@@ -414,6 +486,7 @@ func (data *AnycastGateways) fromBodyUnknowns(ctx context.Context, res gjson.Res
 				return true
 			},
 		)
+		_ = r
 		if data.AnycastGateways[i].Id.IsUnknown() {
 			if value := r.Get("id"); value.Exists() && !data.AnycastGateways[i].Id.IsNull() {
 				data.AnycastGateways[i].Id = types.StringValue(value.String())

--- a/internal/provider/model_catalystcenter_fabric_devices.go
+++ b/internal/provider/model_catalystcenter_fabric_devices.go
@@ -305,6 +305,7 @@ func (data *FabricDevices) fromBodyUnknowns(ctx context.Context, res gjson.Resul
 				return true
 			},
 		)
+		_ = r
 		if data.FabricDevices[i].Id.IsUnknown() {
 			if value := r.Get("id"); value.Exists() && !data.FabricDevices[i].Id.IsNull() {
 				data.FabricDevices[i].Id = types.StringValue(value.String())

--- a/internal/provider/model_catalystcenter_fabric_l3_handoff_ip_transits.go
+++ b/internal/provider/model_catalystcenter_fabric_l3_handoff_ip_transits.go
@@ -334,6 +334,7 @@ func (data *FabricL3HandoffIPTransits) fromBodyUnknowns(ctx context.Context, res
 				return true
 			},
 		)
+		_ = r
 		if data.L3Handoffs[i].Id.IsUnknown() {
 			if value := r.Get("id"); value.Exists() && !data.L3Handoffs[i].Id.IsNull() {
 				data.L3Handoffs[i].Id = types.StringValue(value.String())

--- a/internal/provider/model_catalystcenter_fabric_multicast_virtual_networks.go
+++ b/internal/provider/model_catalystcenter_fabric_multicast_virtual_networks.go
@@ -398,6 +398,7 @@ func (data *FabricMulticastVirtualNetworks) fromBodyUnknowns(ctx context.Context
 				return true
 			},
 		)
+		_ = r
 		if data.VirtualNetworks[i].Id.IsUnknown() {
 			if value := r.Get("id"); value.Exists() && !data.VirtualNetworks[i].Id.IsNull() {
 				data.VirtualNetworks[i].Id = types.StringValue(value.String())

--- a/internal/provider/model_catalystcenter_fabric_port_assignments.go
+++ b/internal/provider/model_catalystcenter_fabric_port_assignments.go
@@ -301,6 +301,7 @@ func (data *FabricPortAssignments) fromBodyUnknowns(ctx context.Context, res gjs
 				return true
 			},
 		)
+		_ = r
 		if data.PortAssignments[i].Id.IsUnknown() {
 			if value := r.Get("id"); value.Exists() && !data.PortAssignments[i].Id.IsNull() {
 				data.PortAssignments[i].Id = types.StringValue(value.String())

--- a/internal/provider/model_catalystcenter_planned_access_point_position.go
+++ b/internal/provider/model_catalystcenter_planned_access_point_position.go
@@ -408,6 +408,7 @@ func (data *PlannedAccessPointPosition) fromBodyUnknowns(ctx context.Context, re
 				return true
 			},
 		)
+		_ = r
 		if data.Radios[i].RadioId.IsUnknown() {
 			if value := r.Get("id"); value.Exists() && !data.Radios[i].RadioId.IsNull() {
 				data.Radios[i].RadioId = types.StringValue(value.String())

--- a/internal/provider/model_catalystcenter_provision_devices.go
+++ b/internal/provider/model_catalystcenter_provision_devices.go
@@ -206,6 +206,7 @@ func (data *ProvisionDevices) fromBodyUnknowns(ctx context.Context, res gjson.Re
 				return true
 			},
 		)
+		_ = r
 		if data.ProvisionDevices[i].Id.IsUnknown() {
 			if value := r.Get("id"); value.Exists() && !data.ProvisionDevices[i].Id.IsNull() {
 				data.ProvisionDevices[i].Id = types.StringValue(value.String())

--- a/internal/provider/resource_catalystcenter_anycast_gateway.go
+++ b/internal/provider/resource_catalystcenter_anycast_gateway.go
@@ -97,6 +97,25 @@ func (r *AnycastGatewayResource) Schema(ctx context.Context, req resource.Schema
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"additional_ip_pools": schema.ListNestedAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Names of up to 4 additional (secondary) IP pools associated with the anycast gateway. Additional IP pools provide more IP addresses that can be used when the primary IP pool is exhausted. When an additional IP pool is exhausted, the next IP pool is used. The order in which the additional IP pools are used is defined by the order property. IP pools with lower order numbers will be used first (not applicable to INFRA_VN)").String,
+				Optional:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Name of the additional IP pool associated with the anycast gateway").String,
+							Required:            true,
+						},
+						"order": schema.Int64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Sequence in which this IP pool will be used").AddIntegerRangeDescription(2, 5).String,
+							Required:            true,
+							Validators: []validator.Int64{
+								int64validator.Between(2, 5),
+							},
+						},
+					},
+				},
+			},
 			"tcp_mss_adjustment": schema.Int64Attribute{
 				MarkdownDescription: helpers.NewAttributeDescription("TCP maximum segment size adjustment").AddIntegerRangeDescription(500, 1440).String,
 				Optional:            true,

--- a/internal/provider/resource_catalystcenter_anycast_gateways.go
+++ b/internal/provider/resource_catalystcenter_anycast_gateways.go
@@ -104,6 +104,25 @@ func (r *AnycastGatewaysResource) Schema(ctx context.Context, req resource.Schem
 							MarkdownDescription: helpers.NewAttributeDescription("Name of the IP pool associated with the anycast gateway").String,
 							Required:            true,
 						},
+						"additional_ip_pools": schema.ListNestedAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Names of up to 4 additional (secondary) IP pools associated with the anycast gateway. Additional IP pools provide more IP addresses that can be used when the primary IP pool is exhausted. When an additional IP pool is exhausted, the next IP pool is used. The order in which the additional IP pools are used is defined by the order property. IP pools with lower order numbers will be used first (not applicable to INFRA_VN)").String,
+							Optional:            true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"name": schema.StringAttribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Name of the additional IP pool associated with the anycast gateway").String,
+										Required:            true,
+									},
+									"order": schema.Int64Attribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Sequence in which this IP pool will be used").AddIntegerRangeDescription(2, 5).String,
+										Required:            true,
+										Validators: []validator.Int64{
+											int64validator.Between(2, 5),
+										},
+									},
+								},
+							},
+						},
 						"tcp_mss_adjustment": schema.Int64Attribute{
 							MarkdownDescription: helpers.NewAttributeDescription("TCP maximum segment size adjustment").AddIntegerRangeDescription(500, 1440).String,
 							Optional:            true,


### PR DESCRIPTION
This PR superceeds https://github.com/CiscoDevNet/terraform-provider-catalystcenter/pull/476 .
As it decouples the two fixes in the original PR.

This is the first part

 Adds supports for additional IP pools for anycast gateway supported in 3.2.X