### PR TITLE
Feature/anchor vn guard

### DIFF
--- a/internal/provider/resource_catalystcenter_fabric_l3_virtual_network.go
+++ b/internal/provider/resource_catalystcenter_fabric_l3_virtual_network.go
@@ -484,9 +484,9 @@ func (r *FabricL3VirtualNetworkResource) Update(ctx context.Context, req resourc
 	// Verified via live API testing: Catalyst Center accepts adding an anchor to an
 	// existing VN and removing the anchor while keeping fabric_ids. Those transitions
 	// are allowed here and executed by applyFabricIdsAnchorAware / the unassociate path.
-	// Only in-place anchor *replacement* (one non-empty anchor site to a different
-	// non-empty anchor site) remains blocked, because that transition — especially with
-	// multi-fabric membership — has not been verified against Catalyst Center.
+	// In-place anchor *replacement* (one non-empty anchor site to a different non-empty
+	// anchor site) is blocked: Catalyst Center itself does not support re-anchoring an
+	// existing L3 VN — the CatC GUI does not allow changing the anchor site either.
 	stateAnchor := ""
 	if !state.AnchoredSiteId.IsNull() {
 		stateAnchor = state.AnchoredSiteId.ValueString()
@@ -504,7 +504,7 @@ func (r *FabricL3VirtualNetworkResource) Update(ctx context.Context, req resourc
 	if anchorReplaced {
 		resp.Diagnostics.AddError(
 			"Invalid Configuration",
-			"Changing anchored_site_id from one non-empty fabric site to another in a single update is blocked by this provider. Remove the anchor first (apply), then add the new anchor in a subsequent apply, or destroy and recreate the resource.",
+			"Catalyst Center does not allow changing the anchor site of an existing Layer 3 Virtual Network (the same restriction applies in the Catalyst Center GUI). To move the anchor to a different fabric site, first remove the anchor (apply), then add the new anchor in a subsequent apply, or destroy and recreate the resource.",
 		)
 		return
 	}

--- a/internal/provider/resource_catalystcenter_fabric_l3_virtual_network.go
+++ b/internal/provider/resource_catalystcenter_fabric_l3_virtual_network.go
@@ -481,8 +481,12 @@ func (r *FabricL3VirtualNetworkResource) Update(ctx context.Context, req resourc
 	}
 
 	// Anchor-mutation guard.
-	// Catalyst Center does not allow adding, changing, or removing the anchor on
-	// an existing L3 VN that still has fabric associations.
+	// Verified via live API testing: Catalyst Center accepts adding an anchor to an
+	// existing VN and removing the anchor while keeping fabric_ids. Those transitions
+	// are allowed here and executed by applyFabricIdsAnchorAware / the unassociate path.
+	// Only in-place anchor *replacement* (one non-empty anchor site to a different
+	// non-empty anchor site) remains blocked, because that transition — especially with
+	// multi-fabric membership — has not been verified against Catalyst Center.
 	stateAnchor := ""
 	if !state.AnchoredSiteId.IsNull() {
 		stateAnchor = state.AnchoredSiteId.ValueString()
@@ -496,10 +500,11 @@ func (r *FabricL3VirtualNetworkResource) Update(ctx context.Context, req resourc
 	planFabricIdsEmpty := plan.FabricIds.IsNull() || len(planFabricIdsForAnchorCheck) == 0
 	anchorRemovedWithEmptyFabricIds := stateAnchor != "" && planAnchor == "" && planFabricIdsEmpty
 
-	if stateAnchor != planAnchor && !anchorRemovedWithEmptyFabricIds {
+	anchorReplaced := stateAnchor != "" && planAnchor != "" && stateAnchor != planAnchor
+	if anchorReplaced {
 		resp.Diagnostics.AddError(
 			"Invalid Configuration",
-			"Catalyst Center does not allow adding, changing, or removing the anchor of an existing Layer 3 Virtual Network. The only permitted anchor mutation via Update is removing the anchor together with emptying fabric_ids (effectively unassociating the VN from all fabric sites). For any other anchor change you must destroy and recreate the resource.",
+			"Changing anchored_site_id from one non-empty fabric site to another in a single update is blocked by this provider. Remove the anchor first (apply), then add the new anchor in a subsequent apply, or destroy and recreate the resource.",
 		)
 		return
 	}

--- a/internal/provider/resource_catalystcenter_fabric_l3_virtual_network.go
+++ b/internal/provider/resource_catalystcenter_fabric_l3_virtual_network.go
@@ -110,6 +110,10 @@ func (r *FabricL3VirtualNetworkResource) Configure(_ context.Context, req resour
 
 // End of section. //template:end model
 
+// Interface assertion placed outside the generated marker section so `go generate`
+// does not strip it (the generator template does not emit ResourceWithModifyPlan).
+var _ resource.ResourceWithModifyPlan = &FabricL3VirtualNetworkResource{}
+
 func (r *FabricL3VirtualNetworkResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan FabricL3VirtualNetwork
 
@@ -448,6 +452,40 @@ func (r *FabricL3VirtualNetworkResource) Read(ctx context.Context, req resource.
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
+}
+
+// ModifyPlan rejects anchor-site replacement at plan time so `terraform plan` fails fast,
+// rather than surfacing the error mid-apply from Update(). Catalyst Center does not allow
+// changing the anchor site of an existing L3 VN (the GUI blocks it too). Adding an anchor
+// (null -> X) and removing it (X -> null) stay allowed and fall through to Update().
+func (r *FabricL3VirtualNetworkResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var state, plan FabricL3VirtualNetwork
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if state.AnchoredSiteId.IsNull() || state.AnchoredSiteId.IsUnknown() {
+		return
+	}
+	if plan.AnchoredSiteId.IsNull() || plan.AnchoredSiteId.IsUnknown() {
+		return
+	}
+
+	stateAnchor := state.AnchoredSiteId.ValueString()
+	planAnchor := plan.AnchoredSiteId.ValueString()
+	if stateAnchor != "" && planAnchor != "" && stateAnchor != planAnchor {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("anchored_site_id"),
+			"Invalid Configuration",
+			"Catalyst Center does not allow changing the anchor site of an existing Layer 3 Virtual Network (the same restriction applies in the Catalyst Center GUI). To move the anchor to a different fabric site, first remove the anchor (apply), then add the new anchor in a subsequent apply, or destroy and recreate the resource.",
+		)
+	}
 }
 
 func (r *FabricL3VirtualNetworkResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {


### PR DESCRIPTION
This PR superceeds https://github.com/CiscoDevNet/terraform-provider-catalystcenter/pull/476 .
As it decouples the two fixes in the original PR.

This is the second part and it:

a)Fixes minor issues with anchor VN guard
b)Adds a new terrafrom plan-time guard, that prevents a user from unintentionally changing the Achor Site associated to the anchor VN after it deployed. - Allowing this would cause partial destruction of anycast gateways resources belonging to the anchor VN